### PR TITLE
Don't default dovecot to replicate to anotherhost.example.com

### DIFF
--- a/charts/docker-mailserver/templates/configmap.yaml
+++ b/charts/docker-mailserver/templates/configmap.yaml
@@ -94,7 +94,7 @@ data:
     }
 
     plugin {
-      mail_replica = tcp:anotherhost.example.com # use doveadm_port
+      #mail_replica = tcp:anotherhost.example.com       # use doveadm_port
       #mail_replica = tcp:anotherhost.example.com:12345 # use port 12345 explicitly
     }
 


### PR DESCRIPTION
(closes #9)