### PR TITLE
Fix comments in values.yaml for initContainer resources

### DIFF
--- a/charts/docker-mailserver/values.yaml
+++ b/charts/docker-mailserver/values.yaml
@@ -8,27 +8,18 @@ image:
 
 initContainer:
   image:
-    # image.name is the name of the container image to use. Refer to https://hub.docker.com/r/tvial/docker-mailserver
     name: "busybox"
-    # image.tag is the tag of the container image to use. Refer to https://hub.docker.com/r/tvial/docker-mailserver
     tag: "1.28"
     pullPolicy: "IfNotPresent"
 
-  # These resources refer specifically to the _init container_, which needs only _puny_ resources, since all it does
-  
+  # These resources refer specifically to the _init container_, which needs only _puny_ resources,
+  # since all it does is copy the config into place
   resources:
     requests:
-      ## How much CPU this container is expected to need
       cpu: "10m"
-      ## How much memory this container is expected to need.
-      ## Reduce these at requests your peril - too few resources can cause daemons (i.e., clamd) to fail, or timeouts to occur.
-      ## A test installation with clamd running was killed when it consumed 1437Mi (which is why this value was increased to 1536)
       memory: "32Mi"
     limits:
-      ## The max CPU this container should be allowed to use
       cpu: "50m"
-      ## The max memory this container should be allowed to use. Note: If a container exceeds its memory limit,
-      ## it may terminated.
       memory: "64Mi"
 
 serviceAccount:


### PR DESCRIPTION
These comments appear to be copy/paste from the resource descriptions for the main mail server container resource limits, and do not make sense in this context. It also finishes a sentence which was either cut off or never

...finished. :)