### PR TITLE
Skip creating ServiceAccount for Rainloop if it is disabled

### DIFF
--- a/charts/docker-mailserver/templates/serviceaccount-rainloop.yaml
+++ b/charts/docker-mailserver/templates/serviceaccount-rainloop.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.serviceAccount.create -}}
+{{- if and .Values.rainloop.enabled .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:


### PR DESCRIPTION
When Rainloop is disabled, we should not create a ServiceAccount for it