### PR TITLE
Fix load balancer traffic policy

### DIFF
--- a/charts/docker-mailserver/templates/service.yaml
+++ b/charts/docker-mailserver/templates/service.yaml
@@ -11,9 +11,6 @@ metadata:
     prometheus.io/path: {{ .Values.monitoring.service.path | quote }}
     prometheus.io/port: {{ .Values.monitoring.service.port | quote }}
     ##  
-    ## If a load balancer is being used, ensure that the newer type of LB that passes along IP information is used
-    ## rather than the legacy one.
-    {{- if eq .Values.service.type "LoadBalancer" }}service.beta.kubernetes.io/external-traffic: "OnlyLocal"{{ end }}
   {{- if .Values.service.annotations }}
   {{ toYaml .Values.service.annotations | indent 2 }}  
   {{ end }}    
@@ -24,6 +21,13 @@ metadata:
     release: "{{ .Release.Name }}"
   name: {{ template "dockermailserver.fullname" . }}
 spec:
+  ## If a load balancer is being used, ensure that the newer type of LB that passes along IP information is used
+  ## rather than the legacy one.
+  {{- if eq .Values.service.type "LoadBalancer" }}
+  externalTrafficPolicy: Local
+  {{ else }}
+  externalTrafficPolicy: Cluster
+  {{ end }}
   selector:
     app: {{ template "dockermailserver.fullname" . }}
     release: "{{ .Release.Name }}"
@@ -87,8 +91,7 @@ spec:
   loadBalancerIP: {{ .Values.service.loadBalancer.publicIp }}
   {{ if .Values.service.loadBalancer.allowedIps -}}
   loadBalancerSourceRanges:
-{{ .Values.service.loadBalancer.allowedIps | toYaml | indent 4 }}
+  {{ .Values.service.loadBalancer.allowedIps | toYaml | indent 4 }}
   {{ end -}}
   {{ end -}}
   {{ end }}
-  externalTrafficPolicy: Local


### PR DESCRIPTION
This makes two changes:
First, it upgrades the syntax to use newer version of the external traffic policy. This is based on testing on my Kubernetes 1.15 cluster, and was discovered from [this reference](https://github.com/kubernetes/ingress-nginx/issues/1924)
Second, it makes the non-load-balancer case switch to Cluster policy, which is necessary to allow the cluster to route NodePort traffic without a Kubernetes load balancer

Also, fixed tiny whitespace nit