### PR TITLE
Rename dovecot.cf to dovecot-services.cf

### DIFF
--- a/charts/docker-mailserver/templates/configmap.yaml
+++ b/charts/docker-mailserver/templates/configmap.yaml
@@ -37,7 +37,7 @@ data:
   {{ if .Values.spfTestsDisabled }}
     smtpd_recipient_restrictions = permit_sasl_authenticated, permit_mynetworks, reject_unauth_destination, reject_unauth_pipelining, reject_invalid_helo_hostname, reject_non_fqdn_helo_hostname, reject_unknown_recipient_domain, reject_rbl_client zen.spamhaus.org, reject_rbl_client bl.spamcop.net
   {{ end -}}
-  dovecot.cf: |
+  dovecot-services.cf: |
   {{- if .Values.haproxy.enabled }}
     haproxy_trusted_networks = {{ .Values.haproxy.trustedNetworks }}
   {{ end }}

--- a/charts/docker-mailserver/templates/deployment.yaml
+++ b/charts/docker-mailserver/templates/deployment.yaml
@@ -88,6 +88,10 @@ spec:
               mountPath: /var/mail-state
               subPath: mail-state
             - name: configmap
+              subPath: dovecot-services.cf
+              mountPath: /etc/dovecot/conf.d/services.cf
+              readOnly: true  
+            - name: configmap
               subPath: dovecot.cf
               mountPath: /etc/dovecot/conf.d/zz-custom.cf
               readOnly: true  


### PR DESCRIPTION
Prior to this change there was a file named `config/dovecot.cf` which appeared to be placed to chart users could add arbitrary custom Dovecot configuration. This name conflicted with the services defined in `templates/configmap.yaml`, so it was never actually staged. This PR renames the one in `configmap.yaml` so both may be used.