### PR TITLE
Document possible values for ldap_start_tls

### DIFF
--- a/charts/docker-mailserver/values.yaml
+++ b/charts/docker-mailserver/values.yaml
@@ -168,7 +168,7 @@ pod:
     enable_fetchmail: 0
     fetchmail_poll: 300
     enable_ldap: 
-    ldap_start_tls:
+    ldap_start_tls: # MUST BE "yes" or "no" - quoted strings
     ldap_server_host: 
     ldap_search_base:
     ldap_bind_dn:


### PR DESCRIPTION
I had this set to the value of `yes` (no quotes), which was interpreted as a boolean somewhere in the chain, causing my rendered configuration to have `start_tls = true`. Unfortuantely postfix only accepts a literal `yes` or `no`. Thus, to make sure it gets all the way to Postfix in the correct form, it is important that this string is quoted.