### PR TITLE
Fix spfTestsDisbled logic; add rblRejectDomains configuration

### DIFF
--- a/charts/docker-mailserver/templates/configmap.yaml
+++ b/charts/docker-mailserver/templates/configmap.yaml
@@ -34,8 +34,8 @@ data:
   {{- if .Values.haproxy.enabled }}  # Necessary to permit proxy protocol from haproxy to postscreen
     postscreen_upstream_proxy_protocol = haproxy
   {{ end }}
-  {{ if .Values.spfTestsDisabled }}
-    smtpd_recipient_restrictions = permit_sasl_authenticated, permit_mynetworks, reject_unauth_destination, reject_unauth_pipelining, reject_invalid_helo_hostname, reject_non_fqdn_helo_hostname, reject_unknown_recipient_domain, reject_rbl_client zen.spamhaus.org, reject_rbl_client bl.spamcop.net
+  {{ if not .Values.spfTestsDisabled }}
+    smtpd_recipient_restrictions = permit_sasl_authenticated, permit_mynetworks, reject_unauth_destination, reject_unauth_pipelining, reject_invalid_helo_hostname, reject_non_fqdn_helo_hostname, reject_unknown_recipient_domain, reject_rbl_client zen.spamhaus.org, reject_rbl_client bl.spamcop.net{{ range .Values.rblRejectDomains }}, reject_rbl_client {{ . }}{{ end }}
   {{ end -}}
   dovecot-services.cf: |
   {{- if .Values.haproxy.enabled }}

--- a/charts/docker-mailserver/values.yaml
+++ b/charts/docker-mailserver/values.yaml
@@ -67,6 +67,9 @@ demoMode:
 # spfTestsDisabled will ignore all SPF-based spam tests, in the event that you cannot obtain valid source IP details on ingress emails
 spfTestsDisabled: false
 
+# List extra RBL domains to use for hard reject filtering
+rblRejectDomains: []
+
 # If you're using David's hacked-up automatic external haproxy design, then enable
 # the following to launch the appropriate containers to call back to the haproxy webhook
 # Details at https://www.funkypenguin.co.nz/project/a-simple-free-load-balancer-for-your-kubernetes-cluster/ 


### PR DESCRIPTION
I'm pretty sure the spfTestsDisabled logic was backwards.

Also add an option to add extra domains to the rbl configuration.
I am not sure if it'd been better to have all the existing domains
just in the default values.yaml instead of hard-coded.