### PR TITLE
Fix wrong non-plural named dovecot_*_attr values

### DIFF
--- a/charts/docker-mailserver/templates/_upstream-env-variables.tpl
+++ b/charts/docker-mailserver/templates/_upstream-env-variables.tpl
@@ -91,12 +91,12 @@ We list them here (and include this template in deployment.yaml) to keep deploym
   value: {{ .Values.pod.dockermailserver.dovecot_tls | quote }}
 - name: DOVECOT_USER_FILTER
   value: {{ .Values.pod.dockermailserver.dovecot_user_filter | quote }}
-- name: DOVECOT_USER_ATTR
-  value: {{ .Values.pod.dockermailserver.dovecot_user_attr | quote }}
+- name: DOVECOT_USER_ATTRS
+  value: {{ .Values.pod.dockermailserver.dovecot_user_attrs | quote }}
 - name: DOVECOT_PASS_FILTER
   value: {{ .Values.pod.dockermailserver.dovecot_pass_filter | quote }}
-- name: DOVECOT_PASS_ATTR
-  value: {{ .Values.pod.dockermailserver.dovecot_pass_attr | quote }}
+- name: DOVECOT_PASS_ATTRS
+  value: {{ .Values.pod.dockermailserver.dovecot_pass_attrs | quote }}
 - name: ENABLE_POSTGREY
   value: {{ .Values.pod.dockermailserver.enable_postgrey | quote }}
 - name: POSTGREY_DELAY

--- a/charts/docker-mailserver/values.yaml
+++ b/charts/docker-mailserver/values.yaml
@@ -182,9 +182,9 @@ pod:
     ldap_query_filter_domain:
     dovecot_tls:
     dovecot_user_filter:
-    dovecot_user_attr:
+    dovecot_user_attrs:
     dovecot_pass_filter:
-    dovecot_pass_attr:
+    dovecot_pass_attrs:
     enable_postgrey: 0
     postgrey_delay: 300
     postgrey_max_age: 35


### PR DESCRIPTION
Fixes #29 

Changed in _values.yaml_:
- `dovecot_user_attr` to `dovecot_user_attrs`
- `dovecot_pass_attr` to `dovecot_pass_attrs`
