### PR TITLE
Add more dovecot ldap values

### DIFF
--- a/charts/docker-mailserver/Chart.yaml
+++ b/charts/docker-mailserver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "7.0.0"
 description: A fullstack but simple mailserver (smtp, imap, antispam, antivirus, ssl...) using Docker.
 name: docker-mailserver
-version: 0.2.7
+version: 0.2.8
 sources:
 - https://github.com/funkypenguin/helm-docker-mailserver
 maintainers:

--- a/charts/docker-mailserver/templates/_upstream-env-variables.tpl
+++ b/charts/docker-mailserver/templates/_upstream-env-variables.tpl
@@ -89,6 +89,12 @@ We list them here (and include this template in deployment.yaml) to keep deploym
   value: {{ .Values.pod.dockermailserver.ldap_query_filter_domain | quote }}
 - name: DOVECOT_TLS
   value: {{ .Values.pod.dockermailserver.dovecot_tls | quote }}
+- name: DOVECOT_LDAP_VERSION
+  value: {{ .Values.pod.dockermailserver.dovecot_ldap_version | quote }}
+- name: DOVECOT_DEFAULT_PASS_SCHEME
+  value: {{ .Values.pod.dockermailserver.dovecot_default_pass_scheme | quote }}
+- name: DOVECOT_AUTH_BIND
+  value: {{ .Values.pod.dockermailserver.dovecot_auth_bind | quote }}
 - name: DOVECOT_USER_FILTER
   value: {{ .Values.pod.dockermailserver.dovecot_user_filter | quote }}
 - name: DOVECOT_USER_ATTR

--- a/charts/docker-mailserver/values.yaml
+++ b/charts/docker-mailserver/values.yaml
@@ -181,7 +181,7 @@ pod:
     ldap_query_filter_alias:
     ldap_query_filter_domain:
     dovecot_tls:
-    dovecot_ldap_version:
+    dovecot_ldap_version: 3
     dovecot_default_pass_scheme:
     dovecot_auth_bind:
     dovecot_user_filter:

--- a/charts/docker-mailserver/values.yaml
+++ b/charts/docker-mailserver/values.yaml
@@ -181,6 +181,9 @@ pod:
     ldap_query_filter_alias:
     ldap_query_filter_domain:
     dovecot_tls:
+    dovecot_ldap_version:
+    dovecot_default_pass_scheme:
+    dovecot_auth_bind:
     dovecot_user_filter:
     dovecot_user_attr:
     dovecot_pass_filter:


### PR DESCRIPTION
This PR adds 3 ldap-specific _dovecot_ values, which are passed as _environment variables_ to docker.

- `pod.dockermailserver.dovecot_ldap_version` as `DOVECOT_LDAP_VERSION`
- `pod.dockermailserver.dovecot_default_pass_scheme` as `DOVECOT_DEFAULT_PASS_SCHEME`
- `pod.dockermailserver.dovecot_auth_bind` as `DOVECOT_AUTH_BIND`

Poorly, they are not documented in _docker-mailserver_'s Readme. But available because of it's [configomat template](https://github.com/tomav/docker-mailserver/blob/master/target/dovecot/dovecot-ldap.conf.ext), which is updated on container [start](https://github.com/tomav/docker-mailserver/blob/master/target/start-mailserver.sh#L777).