### PR TITLE
add additionalMounts and additionalVolumeMounts to values and deployment

### DIFF
--- a/charts/docker-mailserver/Chart.yaml
+++ b/charts/docker-mailserver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "8.0.1"
 description: A fullstack but simple mailserver (smtp, imap, antispam, antivirus, ssl...) using Docker.
 name: docker-mailserver
-version: 0.3.2
+version: 0.3.3
 sources:
 - https://github.com/funkypenguin/helm-docker-mailserver
 maintainers:

--- a/charts/docker-mailserver/templates/deployment.yaml
+++ b/charts/docker-mailserver/templates/deployment.yaml
@@ -53,6 +53,9 @@ spec:
              secretName: {{ template "dockermailserver.fullname" . }}-tls
 {{- end }}
 {{- end }}
+{{ if .Values.additionalVolumes }}
+{{- toYaml .Values.additionalVolumes | indent 9 }}
+{{- end }}
       initContainers:
         - name: prep-config
           image: {{ .Values.initContainer.image.name }}:{{ .Values.initContainer.image.tag }}
@@ -143,6 +146,9 @@ spec:
               readOnly: true
               {{- end }}
               {{- end }}
+{{ if .Values.additionalVolumeMounts }}
+{{ toYaml .Values.additionalVolumeMounts | indent 12 }}
+{{- end }}
           livenessProbe:
             exec:
                command:

--- a/charts/docker-mailserver/values.yaml
+++ b/charts/docker-mailserver/values.yaml
@@ -59,6 +59,15 @@ ssl:
 psp:
   create: true
 
+## Mount additional volumes into the container.  Useful for persistent logs or
+## injecting additional config files.
+#additionalVolumes:
+#  - name: "additional"
+#    emptyDir: {}
+#additionalVolumeMounts:
+#  - name: additional
+#    mountPath: /additional
+
 demoMode:
   # demoMode.enabled ignores the contents of helm-chart/docker-mailserver/config and creates minimal static configuration to be used instead. A single account (user "user@example.com", password "password") will be configured for the purpose of validating core functions and connectivity, before applying user config
   enabled: true


### PR DESCRIPTION
This is to simplify injecting semi-dynamic configuration files (for example
postfix maps modified by an external program) into the container.

example usage:

```
additionalVolumes:
  - name: "custommaps-postfix"
    persistentVolumeClaim:
      claimName: custommaps-postfix
              
additionalVolumeMounts:
  - name: custommaps-postfix
    mountPath: /etc/postfix/custommaps
```

And then `custommaps-postfix` can be a shared volume that a CronJob updates periodically with new maps.