### PR TITLE
Fix instructions for locally running lint.

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -23,7 +23,7 @@ We use helm's [chart-testing](https://github.com/helm/chart-testing) tool to lin
 To run in Docker:
 
 1. Have Docker installed
-2. Run `./ci/scripts/local-lint`
+2. Run `.ci/scripts/local-ct-lint.sh`
 
 To run locally:
 


### PR DESCRIPTION
Instructions were pointing at a non-existent path.

There are some other instructions that point to non-existent files (for running tests) but the fix for them isn't obvious.