### PR TITLE
fix ingress upgrade from v1beta to v1 by adjusting the changes according to: https://kubernetes.io/docs/concepts/services-networking/ingress/

### DIFF
--- a/charts/docker-mailserver/Chart.yaml
+++ b/charts/docker-mailserver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "8.0.1"
 description: A fullstack but simple mailserver (smtp, imap, antispam, antivirus, ssl...) using Docker.
 name: docker-mailserver
-version: 0.3.3
+version: 0.3.4
 sources:
 - https://github.com/funkypenguin/helm-docker-mailserver
 maintainers:

--- a/charts/docker-mailserver/templates/ingress-rainloop.yaml
+++ b/charts/docker-mailserver/templates/ingress-rainloop.yaml
@@ -32,10 +32,13 @@ spec:
     - host: {{ . }}
       http:
         paths:
-          - path: {{ $ingressPath }}
+          - pathType: Prefix
+            path: {{ $ingressPath }}
             backend:
-              serviceName: {{ $fullName }}-rainloop
-              servicePort: {{ $servicePort }}
+              service:
+                name: {{ $fullName }}-rainloop
+                port:
+                  number: {{ $servicePort }}
   {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
#45 contained a error. It does not update some naming which was changed from v1beta to v1.
and resulted in an error: 

[ValidationError(Ingress.spec.rules[0].http.paths[0].backend): unknown  field "serviceName" in io.k8s.api.networking.v1.IngressBackend,  ValidationError(Ingress.spec.rules[0].http.paths[0].backend): unknown  field "servicePort" in io.k8s.api.networking.v1.IngressBackend,  ValidationError(Ingress.spec.rules[0].http.paths[0]): missing required  field "pathType" in io.k8s.api.networking.v1.HTTPIngressPath]
