### PR TITLE
support reverse proxies other than haproxy

### DIFF
--- a/charts/docker-mailserver/Chart.yaml
+++ b/charts/docker-mailserver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "11.0.0"
 description: A fullstack but simple mailserver (smtp, imap, antispam, antivirus, ssl...) using Docker.
 name: docker-mailserver
-version: 1.0.0
+version: 1.0.6
 sources:
 - https://github.com/docker-mailserver/docker-mailserver-helm
 maintainers:

--- a/charts/docker-mailserver/README.md
+++ b/charts/docker-mailserver/README.md
@@ -30,6 +30,7 @@ Kubernetes](https://github.com/docker-mailserver/docker-mailserver/wiki/Using-in
       - [Chart Configuration](#chart-configuration)
       - [docker-mailserver Configuration](#docker-mailserver-configuration)
       - [Rainloop Configuration](#rainloop-configuration)
+      - [Traefik as proxy](TRAEFIK_AS_PROXY.md)
       - [HA Proxy-Ingress Configuration](#ha-proxy-ingress-configuration)
   - [Development](#development)
     - [Testing](#testing)
@@ -257,6 +258,8 @@ Values you'll definately want to pay attention to:
 | `rainloop.ingress.hosts` | The hostname(s) to be used via your ingress to access RainLoop | `rainloop.example.com` |
 
 #### HA Proxy-Ingress Configuration
+
+Besides the built-in support for ha-proxy, you can also use [traefik as reverse proxy](TRAEFIK_AS_PROXY.md)
 
 | Parameter                                       | Description                                                                                                                                       | Default                                   |
 |-------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------|

--- a/charts/docker-mailserver/TRAEFIK_AS_PROXY.md
+++ b/charts/docker-mailserver/TRAEFIK_AS_PROXY.md
@@ -1,0 +1,88 @@
+# Running behind Traefik as reverse proxy
+
+Setup according to the [official guide](https://docker-mailserver.github.io/docker-mailserver/edge/examples/tutorials/mailserver-behind-proxy/) with traefik.
+
+### `values.yaml`
+```yaml
+service:
+  type: ClusterIP
+  behind_proxy: true
+  proxy_trusted_networks: "10.42.0.0/16"
+```
+
+Using the following [TCP Route](https://doc.traefik.io/traefik/routing/routers/#configuring-tcp-routers).
+
+```yaml
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRouteTCP
+metadata:
+  name: smtp
+  namespace: mail
+spec:
+  entryPoints:
+    - smtp
+  routes:
+    - match: HostSNI(`*`)
+      services:
+        - name: mail-docker-mailserver
+          namespace: mail
+          port: 25
+          proxyProtocol:
+            version: 1
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRouteTCP
+metadata:
+  name: smtps
+  namespace: mail
+spec:
+  entryPoints:
+    - smtps
+  tls:
+    passthrough: true
+  routes:
+    - match: HostSNI(`*`)
+      services:
+        - name: mail-docker-mailserver
+          namespace: mail
+          port: 465
+          proxyProtocol:
+            version: 1
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRouteTCP
+metadata:
+  name: imaps
+  namespace: mail
+spec:
+  entryPoints:
+    - imaps
+  tls:
+    passthrough: true
+  routes:
+    - match: HostSNI(`*`)
+      services:
+        - name: mail-docker-mailserver
+          namespace: mail
+          port: 10993
+          proxyProtocol:
+            version: 2
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRouteTCP
+metadata:
+  name: submission
+  namespace: mail
+spec:
+  entryPoints:
+    - submission
+  routes:
+    - match: HostSNI(`*`)
+      services:
+        - name: mail-docker-mailserver
+          namespace: mail
+          port: 587
+          proxyProtocol:
+            version: 1
+
+```

--- a/charts/docker-mailserver/templates/configmap.yaml
+++ b/charts/docker-mailserver/templates/configmap.yaml
@@ -31,25 +31,25 @@ data:
   {{- end }}
   postfix-main.cf: |
   {{/* Enable proxy protocol for postscreen / dovecot */}}
-  {{- if .Values.haproxy.enabled }}  # Necessary to permit proxy protocol from haproxy to postscreen
+  {{- if or .Values.service.behind_proxy .Values.rainloop.enabled }}  # Necessary to permit proxy protocol from haproxy to postscreen
     postscreen_upstream_proxy_protocol = haproxy
   {{ end }}
   {{ if not .Values.spfTestsDisabled }}
     smtpd_recipient_restrictions = permit_sasl_authenticated, permit_mynetworks, reject_unauth_destination, reject_unauth_pipelining, reject_invalid_helo_hostname, reject_non_fqdn_helo_hostname, reject_unknown_recipient_domain, reject_rbl_client zen.spamhaus.org, reject_rbl_client bl.spamcop.net{{ range .Values.rblRejectDomains }}, reject_rbl_client {{ . }}{{ end }}
   {{ end -}}
   dovecot-services.cf: |
-  {{- if .Values.haproxy.enabled }}
-    haproxy_trusted_networks = {{ .Values.haproxy.trustedNetworks }}
+  {{- if or .Values.service.behind_proxy .Values.rainloop.enabled }}
+    haproxy_trusted_networks = {{ .Values.service.proxy_trusted_networks }}
   {{ end }}
     service imap-login {
       inet_listener imap {
-        {{ if .Values.haproxy.enabled -}}haproxy = yes{{ end }}
+        {{ if or .Values.service.behind_proxy .Values.rainloop.enabled -}}haproxy = yes{{ end }}
       }  
       inet_listener imaps {
-        {{ if .Values.haproxy.enabled -}}haproxy = yes{{ end }}
+        {{ if or .Values.service.behind_proxy .Values.rainloop.enabled -}}haproxy = yes{{ end }}
       }
-    {{- if .Values.rainloop.enabled }}
-      inet_listener imaps-rainloop {
+    {{- if or .Values.service.behind_proxy .Values.rainloop.enabled }}
+      inet_listener imaps-proxy {
         port = 10993
         ssl = yes
       }
@@ -57,10 +57,10 @@ data:
     }    
     service pop3-login {
       inet_listener pop3 {
-        {{ if .Values.haproxy.enabled -}}haproxy = yes{{ end }}
+        {{ if or .Values.service.behind_proxy .Values.rainloop.enabled -}}haproxy = yes{{ end }}
       }
       inet_listener pop3s {
-        {{ if .Values.haproxy.enabled -}}haproxy = yes{{ end }}
+        {{ if or .Values.service.behind_proxy .Values.rainloop.enabled -}}haproxy = yes{{ end }}
       }                        
     }
 

--- a/charts/docker-mailserver/templates/service.yaml
+++ b/charts/docker-mailserver/templates/service.yaml
@@ -80,9 +80,9 @@ spec:
     - protocol: "TCP"
       name: "tcp-dsync"
       port: 4711        
-  {{- if .Values.rainloop.enabled }}
+  {{- if or .Values.service.behind_proxy .Values.rainloop.enabled }}
     - protocol: "TCP"
-      name: "tcp-imaps-rainloop"
+      name: "tcp-imaps-proxy"
       port: 10993        
   {{ end }}  
   type: {{ default "ClusterIP" .Values.service.type }}

--- a/charts/docker-mailserver/values.yaml
+++ b/charts/docker-mailserver/values.yaml
@@ -263,7 +263,6 @@ service:
   # service.proxy_trusted_networks is the list of sources (in CIDR format, space-separated) to permit haproxy PROXY protocol from
   proxy_trusted_networks: "10.0.0.0/8 192.168.0.0/16 172.16.0.0/16"
 
-
 deployment:
 
   ## How many versions of the deployment to run on kubernetes

--- a/charts/docker-mailserver/values.yaml
+++ b/charts/docker-mailserver/values.yaml
@@ -251,6 +251,18 @@ service:
     # hostName:
   annotations: {}
 
+  # Configure for the scenario described in https://docker-mailserver.github.io/docker-mailserver/edge/examples/tutorials/mailserver-behind-proxy/
+  # to run mailserver behind a reverse proxy like haproxy or traefik
+  behind_proxy: false
+
+  # These values populate dovecot's list of networks it'll "trust" for incoming haproxy connections.
+  # A space-separated list, on a single line, is required
+  # By default, we allow all RFC1918 private ranges, but this can be tightened up for the known IP/range
+  # of your HAProxy instance
+  # service.proxy_trusted_networks is the list of sources (in CIDR format, space-separated) to permit haproxy PROXY protocol from
+  proxy_trusted_networks: "10.0.0.0/8 192.168.0.0/16 172.16.0.0/16"
+
+
 deployment:
 
   ## How many versions of the deployment to run on kubernetes
@@ -393,10 +405,3 @@ haproxy:
 
   defaultBackend:
     replicaCount: 1
-
-  # These values populate dovecot's list of networks it'll "trust" for incoming haproxy connections.
-  # A space-separated list, on a single line, is required
-  # By default, we allow all RFC1918 private ranges, but this can be tightened up for the known IP/range
-  # of your HAProxy instance
-  # haproxy.trustedNetworks is the list of sources (in CIDR format, space-separated) to permit haproxy PROXY protocol from
-  trustedNetworks: "10.0.0.0/8 192.168.0.0/16 172.16.0.0/16"


### PR DESCRIPTION
move `proxy_trusted_networks` from `haproxy` to `service` section since it's not only applicable for haproxy configuration.

In my case, I'm running traefik as described in:
https://docker-mailserver.github.io/docker-mailserver/edge/examples/tutorials/mailserver-behind-proxy/
