### PR TITLE
Secret management and auto-reload

### DIFF
--- a/charts/docker-mailserver/README.md
+++ b/charts/docker-mailserver/README.md
@@ -146,22 +146,54 @@ Enter Password:
 
 ### Setup OpenDKIM
 
-Example output:
+Create the initial configuration:
 
 ```console
 [funkypenguin:~/demo] ./setup.sh config dkim
-"docker inspect" requires at least 1 argument.
-See 'docker inspect --help'.
-
-Usage:  docker inspect [OPTIONS] NAME|ID [NAME|ID...]
-
-Return low-level information on Docker objects
 Creating DKIM private key /tmp/docker-mailserver/opendkim/keys/bob.com/mail.private
 Creating DKIM KeyTable
 Creating DKIM SigningTable
 Creating DKIM private key /tmp/docker-mailserver/opendkim/keys/example.com/mail.private
 Creating DKIM TrustedHosts
 [funkypenguin:~/demo]
+```
+
+Get the configuration:
+
+`kubectl exec -n ${NAMESPACE} -i -t deploy/${RELEASE_NAME}-docker-mailserver -c dockermailserver -- cat /etc/opendkim/TrustedHosts`
+`kubectl exec -n ${NAMESPACE} -i -t deploy/${RELEASE_NAME}-docker-mailserver -c dockermailserver -- cat /etc/opendkim/SigningTable`
+`kubectl exec -n ${NAMESPACE} -i -t deploy/${RELEASE_NAME}-docker-mailserver -c dockermailserver -- cat /etc/opendkim/KeyTable`
+
+Example `values`:
+
+```yaml
+openDKIM:
+  configMap:
+    TrustedHosts: |
+      127.0.0.1
+      localhost
+    SigningTable: |
+      *@example.com mail._domainkey.example.com
+    KeyTable: |
+      mail._domainkey.example.com example.com:mail:/etc/opendkim/keys/example.com/mail.private
+```
+
+This requires the private key to be provided as secret with name `<release-fullname>-dkim-secrets`:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mail-docker-mailserver-dkim-secrets
+  namespace: mail
+  labels:
+    app.kubernetes.io/name: mail
+type: Opaque
+stringData:
+  'example.com-mail.private': |
+    -----BEGIN RSA PRIVATE KEY-----
+    ...
+    -----END RSA PRIVATE KEY-----
 ```
 
 ### Setup RainLoop
@@ -219,6 +251,7 @@ The following table lists the configurable parameters of the docker-mailserver c
 | `pod.dockermailserver.hostPID`                    | Not really sure. TBD.                                                                                                                                                                | `None`                                               |                                           |
 | `pod.dockermailserver.securityContext.privileged` | Whether to run this pod in "privileged" mode.                                                                                                                                        | `false`
 | `service.type`                                    | What scope the service should be exposed in  (*LoadBalancer/NodePort/ClusterIP*)                                                                                                     | `NodePort`                                           |
+ | `openDKIM.configMap`                              | Provide openDKIM configuration. See [openDKIM example config](#setup-opendkim)                                                                                                       |
 | `service.loadBalancer.publicIp`                   | The public IP to assign to the service (*if LoadBalancer*) scope selected above                                                                                                      | `None`                                               |
 | `service.loadBalancer.allowedIps`                 | The IPs allowed to access the sevice, in CIDR format (*if LoadBalancer*) scope selected above                                                                                        | `[ "0.0.0.0/0" ]`                                    |
 | `service.nodeport.smtp`                           | The port exposed on the node the container is running on, which will be forwarded to docker-mailserver's SMTP port (25)                                                              | `30025`                                              |

--- a/charts/docker-mailserver/templates/configmap.yaml
+++ b/charts/docker-mailserver/templates/configmap.yaml
@@ -13,10 +13,6 @@ metadata:
 data:
   {{/* Use sample data if user is running in demo mode */}}
   {{- if .Values.demoMode.enabled -}}  
-  ### We are in demo mode, so add in some sample data for quick testing
-  postfix-accounts.cf: |
-    # A sample user - the password is "password"
-    user@example.com|{SHA512-CRYPT}$6$l4023rZnQEy/l0Rg$JeNjAAICB43VAX7GTJ9jeE7DR0LeyR5nU.ftq3c42T5E1IZSuRBqwM8erRh6t0CyIT6aYpBIAopzcQHNUvMV00
   postfix-virtual.cf: "# Intentionally left empty"
   ### End demo mode data
   {{/* Use real data from "config" subdirectory if user is _not_ running in demo mode */}}  

--- a/charts/docker-mailserver/templates/configmap.yaml
+++ b/charts/docker-mailserver/templates/configmap.yaml
@@ -18,11 +18,6 @@ data:
     # A sample user - the password is "password"
     user@example.com|{SHA512-CRYPT}$6$l4023rZnQEy/l0Rg$JeNjAAICB43VAX7GTJ9jeE7DR0LeyR5nU.ftq3c42T5E1IZSuRBqwM8erRh6t0CyIT6aYpBIAopzcQHNUvMV00
   postfix-virtual.cf: "# Intentionally left empty"
-  SigningTable: "*@example.com mail._domainkey.example.com"
-  KeyTable: "mail._domainkey.example.com example.com:mail:/etc/opendkim/keys/example.com/mail.private"
-  TrustedHosts: |
-    127.0.0.1
-    localhost
   ### End demo mode data
   {{/* Use real data from "config" subdirectory if user is _not_ running in demo mode */}}  
   {{ else -}}
@@ -114,4 +109,18 @@ data:
     {{ . }} && \
     {{- end }}
     echo "All healthy"
+---
+{{- end -}}
+{{- if .Values.openDKIM.configMap -}}
+apiVersion: "v1"
+kind: "ConfigMap"
+metadata:
+  labels:
+    app.kubernetes.io/name: {{ template "dockermailserver.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+  name: {{ template "dockermailserver.fullname" . }}-dkim-configs
+data:
+{{ toYaml .Values.openDKIM.configMap | indent 2 }}
 {{- end -}}

--- a/charts/docker-mailserver/templates/deployment.yaml
+++ b/charts/docker-mailserver/templates/deployment.yaml
@@ -38,8 +38,6 @@ spec:
         - name: "data"
           persistentVolumeClaim:
             claimName: {{ template "dockermailserver.pvcName" . }}
-        - name: "config"
-          emptyDir: {}
         - name: "configmap"
           configMap:
             name: {{ template "dockermailserver.fullname" . }}-configs
@@ -50,42 +48,40 @@ spec:
 {{- end }}
         - name: "opendkim-keys"
           secret:
-            secretName: {{ template "dockermailserver.fullname" . }}-secrets
-{{ if .Values.pod.dockermailserver.ssl_type }}
+            secretName: {{ template "dockermailserver.fullname" . }}-dkim-secrets
+{{- if .Values.pod.dockermailserver.ssl_type }}
         - name: "ssl-cert"
           secret:
-{{ if .Values.ssl.useExisting }}
+{{- if .Values.ssl.useExisting }}
             secretName: {{ .Values.ssl.existingName }}
 {{- else }}
             secretName: {{ template "dockermailserver.fullname" . }}-tls
 {{- end }}
+        - name: accounts
+          secret:
+            secretName: {{ template "dockermailserver.fullname" . }}-accounts
 {{- end }}
-{{ if .Values.additionalVolumes }}
+{{- if .Values.additionalVolumes }}
 {{- toYaml .Values.additionalVolumes | indent 9 }}
 {{- end }}
         - name: tmp
           emptyDir: {}
-      initContainers:
-        - name: prep-config
-          image: {{ .Values.initContainer.image.name }}:{{ .Values.initContainer.image.tag }}
-          imagePullPolicy: {{ .Values.initContainer.image.pullPolicy }}
-          command: [ 'sh','-c', 'cp /tmp/configmaps/* /tmp/docker-mailserver -rfpvL' ]
-          volumeMounts:
-            - name: configmap
-              mountPath: /tmp/configmaps
-              readOnly: true
-            - name: config
-              mountPath: /tmp/docker-mailserver/
-          resources:
-{{ toYaml .Values.initContainer.resources | indent 12 }}
-          securityContext:
-{{ toYaml .Values.initContainer.containerSecurityContext | indent 12 }}
       containers:
         - name: dockermailserver
           env:
 {{- include "dockermailserver.upstream-env-variables" . | nindent 10 }}
           image: {{ .Values.image.name }}:{{ .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - sh
+            - -c
+            - >
+              mkdir -p /tmp/docker-mailserver/opendkim/keys
+              && ln -s /tmp/docker-mailserver-configs/* /tmp/docker-mailserver
+              && ln -s /tmp/docker-mailserver-accounts/* /tmp/docker-mailserver
+              && ln -s /tmp/docker-mailserver-opendkim/* /tmp/docker-mailserver
+              && ln -s /tmp/docker-mailserver-opendkim-keys/* /tmp/docker-mailserver/opendkim/keys
+              && supervisord -c /etc/supervisor/supervisord.conf
           resources:
 {{ toYaml .Values.resources | indent 12 }}
             {{- if eq .Values.pod.dockermailserver.enable_fail2ban 1.0 }}
@@ -96,9 +92,11 @@ spec:
           securityContext:
 {{ toYaml .Values.pod.dockermailserver.containerSecurityContext | indent 12 }}
           volumeMounts:
-            - name: config
-              mountPath: /tmp/docker-mailserver
-{{ if .Values.pod.dockermailserver.ssl_type }}
+            - name: configmap
+              mountPath: /tmp/docker-mailserver-configs
+            - name: accounts
+              mountPath: /tmp/docker-mailserver-accounts
+{{- if .Values.pod.dockermailserver.ssl_type }}
             - name: ssl-cert
               mountPath: /tmp/ssl
               readOnly: true

--- a/charts/docker-mailserver/templates/deployment.yaml
+++ b/charts/docker-mailserver/templates/deployment.yaml
@@ -43,6 +43,11 @@ spec:
         - name: "configmap"
           configMap:
             name: {{ template "dockermailserver.fullname" . }}-configs
+{{- if .Values.openDKIM.configMap }}
+        - name: configmap-dkim
+          configMap:
+            name: {{ template "dockermailserver.fullname" . }}-dkim-configs
+{{- end }}
         - name: "opendkim-keys"
           secret:
             secretName: {{ template "dockermailserver.fullname" . }}-secrets
@@ -114,18 +119,11 @@ spec:
               subPath: dovecot.cf
               mountPath: /etc/dovecot/conf.d/zz-custom.cf
               readOnly: true
-            - name: configmap
-              subPath: TrustedHosts
-              mountPath: /tmp/docker-mailserver/opendkim/TrustedHosts
+{{- if .Values.openDKIM.configMap }}
+            - name: configmap-dkim
+              mountPath: /tmp/docker-mailserver-opendkim
               readOnly: true
-            - name: configmap
-              subPath: SigningTable
-              mountPath: /tmp/docker-mailserver/opendkim/SigningTable
-              readOnly: true
-            - name: configmap
-              subPath: KeyTable
-              mountPath: /tmp/docker-mailserver/opendkim/KeyTable
-              readOnly: true
+{{- end }}
             {{- if .Values.pod.dockermailserver.enable_dovecot_replication }}
             - name: configmap
               subPath: 80-replication.conf
@@ -138,13 +136,13 @@ spec:
             {{ end }}
               {{- if .Values.demoMode.enabled }}
             - name: opendkim-keys
-              mountPath: "/tmp/docker-mailserver/opendkim/keys/example.com/mail.private"
+              mountPath: "/tmp/docker-mailserver-opendkim-keys/example.com/mail.private"
               subPath: "example.com-mail.private"
               readOnly: true
               {{- else -}}
               {{/* Mount a dkim key for every domain configured */}}
               {{- range .Values.domains }}
-              {{- $path := printf "/tmp/docker-mailserver/opendkim/keys/%s/mail.private" . }}
+              {{- $path := printf "/tmp/docker-mailserver-opendkim-keys/%s/mail.private" . }}
               {{- $name := printf "%s-mail.private" . }}
             - name: opendkim-keys
               mountPath: {{ $path }}

--- a/charts/docker-mailserver/templates/secret.yaml
+++ b/charts/docker-mailserver/templates/secret.yaml
@@ -30,3 +30,20 @@ data:
   {{ end -}}
   {{ end }}
 {{- end -}}
+---
+{{- if .Values.demoMode.enabled -}}
+apiVersion: "v1"
+kind: "Secret"
+metadata:
+  labels:
+    app.kubernetes.io/name: {{ template "dockermailserver.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+  name: {{ template "dockermailserver.fullname" . }}-accounts
+data:
+  ### We are in demo mode, so add in some sample data for quick testing
+  postfix-accounts.cf: |
+    # A sample user - the password is "password"
+    user@example.com|{SHA512-CRYPT}$6$l4023rZnQEy/l0Rg$JeNjAAICB43VAX7GTJ9jeE7DR0LeyR5nU.ftq3c42T5E1IZSuRBqwM8erRh6t0CyIT6aYpBIAopzcQHNUvMV00
+{{- end }}

--- a/charts/docker-mailserver/templates/secret.yaml
+++ b/charts/docker-mailserver/templates/secret.yaml
@@ -9,7 +9,7 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
-  name: {{ template "dockermailserver.fullname" . }}-secrets
+  name: {{ template "dockermailserver.fullname" . }}-dkim-secrets
 data:
   {{/* Import any files ending in  .secret, as secrets */}}
   {{- $globdash := .Files.Glob "*.secret" }}

--- a/charts/docker-mailserver/tests/configmap_test.yaml
+++ b/charts/docker-mailserver/tests/configmap_test.yaml
@@ -23,4 +23,12 @@ tests:
 
   - it: manifest should match snapshot
     asserts:
-      - matchSnapshot: {}          
+      - matchSnapshot: {}
+
+  - it: configures openDKIM
+    set:
+      openDKIM.TrustedHosts: something
+    asserts:
+      matchRegex:
+        path: data.TrustedHosts
+        pattern: something

--- a/charts/docker-mailserver/values.yaml
+++ b/charts/docker-mailserver/values.yaml
@@ -90,6 +90,17 @@ domains: []
 #  - your-first-domain.com
 #  - your-second-domain.com
 
+# configmap of the openDKIM setup. Secrets have to be provided in '<release-fullname>-dkim-secrets'
+#openDKIM:
+#  configMap:
+#    TrustedHosts: |
+#      127.0.0.1
+#      localhost
+#    SigningTable: |
+#      *@<domain.tld> mail._domainkey.domain.tld
+#    KeyTable: |
+#      mail._domainkey.domain.tld domain.tld:mail:/etc/opendkim/keys/domain.tld/mail.private
+
 livenessTests:
   # livenessTests.enabled will add a liveness test, which will classify a pod as 'unhealthy' if any livenessTests.commands (below) return non-zero
   enabled: true

--- a/charts/docker-mailserver/values.yaml
+++ b/charts/docker-mailserver/values.yaml
@@ -42,9 +42,24 @@ serviceAccount:
 ##
 configMap:
   useExisting: false
+  # if set to true, the following configmap should be pre-existing:
+  # name: <release-fullname>-configs
+  # data:
+  #  <filename>: as in https://docker-mailserver.github.io/docker-mailserver/edge/config/advanced/optional-config/
 
 secret:
-  useExisting: false  
+  useExisting: false
+  # if set to true, the following secrets are expected to exist:
+  #
+  # name: <release-fullname>-dkim-secrets
+  # data:
+  #   <domain.tld>-mail.private: <private key>
+  #
+  # ----
+  # name: <release-fullname>-accounts
+  # data:
+  #   postfix-accounts.cf: >
+  #   <email>|{SHA512-CRYPT}...
 
 ## These values define how the certificate created by the chart is processed by cert-manager
 ## Ensure you've setup your ClusterIssuers (letsencrypt-staging and letsencrypt-prod) and DNS provider


### PR DESCRIPTION
Due to a bug in k8s ([which will not be fixed soon](https://github.com/kubernetes/kubernetes/issues/50345)), the changes in secrets/configs that are mounted with the `subpath`-feature will not be picked up by the `check-for-changes.sh` script.

With this change it will be supported. 

