### PR TITLE
add postfix metrics exporter

### DIFF
--- a/charts/docker-mailserver/Chart.yaml
+++ b/charts/docker-mailserver/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: "11.0.0"
+appVersion: "11.3.1"
 description: A fullstack but simple mailserver (smtp, imap, antispam, antivirus, ssl...) using Docker.
 name: docker-mailserver
-version: 2.0.0
+version: 2.0.1
 sources:
 - https://github.com/docker-mailserver/docker-mailserver-helm
 maintainers:

--- a/charts/docker-mailserver/README.md
+++ b/charts/docker-mailserver/README.md
@@ -227,10 +227,10 @@ The following table lists the configurable parameters of the docker-mailserver c
 | `service.nodeport.imaps`                          | The port exposed on the node the container is running on, which will be forwarded to docker-mailserver's IMAPS port (993)                                                            | `30993`                                              |
 | `service.nodeport.pop3s`                          | The port exposed on the node the container is running on, which will be forwarded to docker-mailserver's IMAPS port (993)                                                            | `30995`                                              |
 | `deployment.replicas`                             | How many instances of the container to deploy (*only 1 supported currently*)                                                                                                         | `1`                                                  |
-| `resource.requests.cpu`                           | Initial share of CPU requested per-pod                                                                                                                                               | `1`                                                  |
-| `resource.requests.memory`                        | Initial share of RAM requested per-pod (*Initial testing showed clamd would fail due to memory pressure with less than 1.5GB RAM*)                                                   | `1536Mi`                                             |
-| `resource.limits.cpu`                             | Maximum share of CPU available per-pod                                                                                                                                               | `2`                                                  |
-| `resource.limits.memory`                          | Maximum share of RAM available per-pod                                                                                                                                               | `2048Mi`                                             |
+| `resource.requests.cpu`                           | Initial share of CPU requested for dockermailserver                                                                                                                                  | `1`                                                  |
+| `resource.requests.memory`                        | Initial share of RAM requested dockermailserver (*Initial testing showed clamd would fail due to memory pressure with less than 1.5GB                                               | `1536Mi`                                             |
+| `resource.limits.cpu`                             | Maximum share of CPU available dockermailserver                                                                                                                                     | `2`                                                  |
+| `resource.limits.memory`                          | Maximum share of RAM available dockermailserverv                                                                                                                                    | `2048Mi`                                             |
 | `persistence.size`                                | How much space to provision for persistent storage                                                                                                                                   | `10Gi`                                               |
 | `persistence.annotations`                         | Annotations to add to the persistent storage (*for example, to support [k8s-snapshots](https://github.com/miracle2k/k8s-snapshots)*)                                                 | `{}`                                                 |
 | `ssl.issuer.name`                                 | The name of the cert-manager issuer expected to issue certs                                                                                                                          | `letsencrypt-staging`                                |
@@ -269,6 +269,26 @@ Values you'll definately want to pay attention to:
 | `haproxy.tcp.993`                       | How to forward inbound TCP connections on port 993. Use syntax described above.                                                                   | `default/docker-mailserver:993::PROXY-V1` |
 | `haproxy.tcp.995`                       | How to forward inbound TCP connections on port 995. Use syntax described above.                                                                   | `default/docker-mailserver:995::PROXY-V1` |
 | `haproxy.service.externalTrafficPolicy` | Used to preserve source IP per [this doc](https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-type-loadbalancer) | `Local`                                   |
+
+
+#### postfix exporter metrics
+
+| Parameter                               | Description                                                                                   | Default                                                            |
+|-----------------------------------------|-----------------------------------------------------------------------------------------------|--------------------------------------------------------------------|
+| `metrics.enabled`                       | enable postfix exporter metrics for prometheus                                                | `false`                                                            |
+| `metrics.resource.requests.memory`      | Initial share of RAM for metrics sidecar                                                      | `256Mi`                                                            |
+| `metrics.resource.limits.memory`        | Maximum share of RAM for metrics sidecar                                                      | `null`                                                             |
+| `metrics.resource.limits.cpu`           | Maximum share of CPU available for metrics                                                    | `null`                                                             |
+| `metrics.resource.requests.cpu`         | Iniyial share of CPU available per-pod                                                        | `null`                                                             |
+| `metrics.image.name`                    | The name of the container image to use                                                        | `mblackflysolutions/postfix-exporter@sha256`                       |
+| `metrics.image.tag`                     | The image tag. If use named tag, then remove @sha256 from name, else put sha256 signed value  | `7ed7c0534112aff5b44757ae84a206bf659171631edfc325c3c1638d78e74f73` |
+| `metrics.image.pullPolicy`              | pullPolicy                                                                                    | `IfNotPresent`                                                     |
+| `metrics.serviceMonitor.enabled`        | generate serviceMonitor for metrics                                                           | `false`                                                            |
+| `metrics.serviceMonitor.scrapeInterval` | default scrape interval                                                                       | `15s`                                                              |
+
+
+
+
 
 ## Development
 

--- a/charts/docker-mailserver/README.md
+++ b/charts/docker-mailserver/README.md
@@ -280,7 +280,7 @@ Values you'll definately want to pay attention to:
 | `metrics.resource.limits.memory`        | Maximum share of RAM for metrics sidecar                                                      | `null`                                                             |
 | `metrics.resource.limits.cpu`           | Maximum share of CPU available for metrics                                                    | `null`                                                             |
 | `metrics.resource.requests.cpu`         | Iniyial share of CPU available per-pod                                                        | `null`                                                             |
-| `metrics.image.name`                    | The name of the container image to use                                                        | `mblackflysolutions/postfix-exporter@sha256`                       |
+| `metrics.image.name`                    | The name of the container image to use                                                        | `blackflysolutions/postfix-exporter@sha256`                       |
 | `metrics.image.tag`                     | The image tag. If use named tag, then remove @sha256 from name, else put sha256 signed value  | `7ed7c0534112aff5b44757ae84a206bf659171631edfc325c3c1638d78e74f73` |
 | `metrics.image.pullPolicy`              | pullPolicy                                                                                    | `IfNotPresent`                                                     |
 | `metrics.serviceMonitor.enabled`        | generate serviceMonitor for metrics                                                           | `false`                                                            |

--- a/charts/docker-mailserver/README.md
+++ b/charts/docker-mailserver/README.md
@@ -272,6 +272,7 @@ Values you'll definately want to pay attention to:
 
 
 #### postfix exporter metrics
+* use dashboard :  https://grafana.com/grafana/dashboards/10013-postfix/
 
 | Parameter                               | Description                                                                                   | Default                                                            |
 |-----------------------------------------|-----------------------------------------------------------------------------------------------|--------------------------------------------------------------------|

--- a/charts/docker-mailserver/templates/deployment.yaml
+++ b/charts/docker-mailserver/templates/deployment.yaml
@@ -56,7 +56,7 @@ spec:
 {{- end }}
 {{- end }}
 {{ if .Values.additionalVolumes }}
-{{- toYaml .Values.additionalVolumes | indent 9 }}
+{{- toYaml .Values.additionalVolumes | indent 8 }}
 {{- end }}
         - name: tmp
           emptyDir: {}

--- a/charts/docker-mailserver/templates/deployment.yaml
+++ b/charts/docker-mailserver/templates/deployment.yaml
@@ -76,6 +76,7 @@ spec:
           securityContext:
 {{ toYaml .Values.initContainer.containerSecurityContext | indent 12 }}
       containers:
+
         - name: dockermailserver
           env:
 {{- include "dockermailserver.upstream-env-variables" . | nindent 10 }}
@@ -100,6 +101,11 @@ spec:
 {{- end }}
             - name: tmp
               mountPath: /var/tmp
+{{ if .Values.metrics.enabled }}
+            - name: data
+              mountPath: /var/log/mail
+              subPath: log
+{{- end }}
             - name: data
               mountPath: /var/mail
               subPath: mail      
@@ -173,5 +179,37 @@ spec:
             initialDelaySeconds: 10
             timeoutSeconds: 1
             failureThreshold: 3
-      restartPolicy: "Always"
 
+{{ if .Values.metrics.enabled }}
+        - name: metrics-exporter
+          image: {{ .Values.metrics.image.name }}:{{ .Values.metrics.image.tag }}
+          imagePullPolicy: {{ .Values.metrics.image.pullPolicy }}
+          command: ["/bin/postfix_exporter"]
+          args: 
+            - "--postfix.showq_path"
+            - "/var/mail-state/spool-postfix/public/showq"
+            - "--postfix.logfile_path"
+            - "/var/log/mail/mail.log"
+
+          ports:
+            - containerPort: 9154
+              name: http
+              protocol: TCP
+          resources:
+{{ toYaml .Values.metrics.resources | indent 12 }}          
+          securityContext:
+{{ toYaml .Values.pod.dockermailserver.containerSecurityContext | indent 12 }}
+
+          volumeMounts:
+            - name: data
+              mountPath: /var/log/mail
+              subPath: log
+              readOnly: true     
+            - name: data
+              mountPath: /var/mail-state
+              subPath: mail-state
+              readOnly: true
+{{- end }}
+
+
+      restartPolicy: "Always"

--- a/charts/docker-mailserver/templates/service.yaml
+++ b/charts/docker-mailserver/templates/service.yaml
@@ -84,7 +84,17 @@ spec:
     - protocol: "TCP"
       name: "tcp-imaps-rainloop"
       port: 10993        
-  {{ end }}  
+  {{ end }}
+
+  {{- if .Values.metrics.enabled }}
+    - name: tcp-metrics
+      port: 9154
+      protocol: TCP
+      targetPort: 9154       
+  {{ end }}
+
+
+
   type: {{ default "ClusterIP" .Values.service.type }}
   {{ if eq .Values.service.type "LoadBalancer" -}}
   {{ if .Values.service.loadBalancer.publicIp -}}

--- a/charts/docker-mailserver/templates/servicemonitor.yaml
+++ b/charts/docker-mailserver/templates/servicemonitor.yaml
@@ -1,0 +1,25 @@
+{{- if  .Values.metrics.serviceMonitor.enabled }}
+
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/name: {{ template "dockermailserver.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+  name: {{ template "dockermailserver.fullname" . }}
+spec:
+  endpoints:
+    - interval: {{ .Values.metrics.serviceMonitor.scrapeInterval }}
+      path: /metrics
+      port: tcp-metrics
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "dockermailserver.fullname" . }}
+      release: "{{ .Release.Name }}"
+
+{{- end }}

--- a/charts/docker-mailserver/values.yaml
+++ b/charts/docker-mailserver/values.yaml
@@ -403,3 +403,29 @@ haproxy:
   # of your HAProxy instance
   # haproxy.trustedNetworks is the list of sources (in CIDR format, space-separated) to permit haproxy PROXY protocol from
   trustedNetworks: "10.0.0.0/8 192.168.0.0/16 172.16.0.0/16"
+
+
+# when metrics is enabled, we mount subpath log from pvc into /var/log/mail
+metrics:
+  enabled: false
+  image:
+    name: blackflysolutions/postfix-exporter@sha256
+    tag: 7ed7c0534112aff5b44757ae84a206bf659171631edfc325c3c1638d78e74f73
+    pullPolicy: "IfNotPresent"
+
+  resources:
+    requests:
+      memory: "256Mi"
+    #  cpu: "100M"
+    #limits:
+    #  memory: "256Mi"
+    #  cpu: "500M"
+
+
+  serviceMonitor:
+    enabled: false
+    scrapeInterval: 15s
+
+
+      
+


### PR DESCRIPTION
New values `metrics` allow to export postfix metrics for prometheus
You can also generate a serviceMonitor if you use prometheus operator

* example of values for metrics

```
# when metrics is enabled, we mount subpath log from pvc into /var/log/mail
metrics:
  enabled: true
  image:
    name: blackflysolutions/postfix-exporter@sha256
    tag: 7ed7c0534112aff5b44757ae84a206bf659171631edfc325c3c1638d78e74f73
    pullPolicy: "IfNotPresent"

  resources:
    requests:
      memory: "256Mi"
    #  cpu: "100M"
    #limits:
    #  memory: "256Mi"
    #  cpu: "500M"


  serviceMonitor:
    enabled: true
    scrapeInterval: 15s
```