### PR TITLE
Fix nil pointer error in Helm chart by correcting tls secret reference

### DIFF
--- a/charts/docker-mailserver/templates/ingress-rspamd.yaml
+++ b/charts/docker-mailserver/templates/ingress-rspamd.yaml
@@ -28,7 +28,7 @@ spec:
 
 {{ if .Values.rspamd.ingress.tls.enabled }}
   tls:
-  - secretName: {{ .Values.ingress.tls.secret }}
+  - secretName: {{ .Values.rspamd.ingress.tls.secret }}
     hosts:
     -  {{ .Values.rspamd.ingress.host }}
 {{- end }}


### PR DESCRIPTION
This commit fixes a nil pointer error encountered during Helm upgrade caused by an incorrect reference to the TLS secret in the ingress template. The reference `.Values.ingress.tls.secret` has been corrected to `.Values.rspamd.ingress.tls.secret` to match the structure outlined in the Helm values file, ensuring the TLS configuration is correctly applied to the ingress resource.