### PR TITLE
Fix typo in ServiceMonitor port name

### DIFF
--- a/charts/docker-mailserver/Chart.yaml
+++ b/charts/docker-mailserver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "13.3.1"
 description: A fullstack but simple mailserver (smtp, imap, antispam, antivirus, ssl...) using Docker.
 name: docker-mailserver
-version: 3.0.7
+version: 3.0.8
 sources:
 - https://github.com/docker-mailserver/docker-mailserver-helm
 maintainers:

--- a/charts/docker-mailserver/templates/servicemonitor.yaml
+++ b/charts/docker-mailserver/templates/servicemonitor.yaml
@@ -13,7 +13,7 @@ spec:
   endpoints:
     - interval: {{ .Values.metrics.serviceMonitor.scrapeInterval }}
       path: /metrics
-      port: tcp-metrics
+      port: metrics
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}


### PR DESCRIPTION
The service port name is metrics, not tcp-metrics