### PR TITLE
Add smtp to proxy protocol setup

### DIFF
--- a/charts/docker-mailserver/Chart.yaml
+++ b/charts/docker-mailserver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "13.3.1"
 description: A fullstack but simple mailserver (smtp, imap, antispam, antivirus, ssl...) using Docker.
 name: docker-mailserver
-version: 3.0.13
+version: 3.0.14
 sources:
 - https://github.com/docker-mailserver/docker-mailserver-helm
 maintainers:

--- a/charts/docker-mailserver/templates/deployment.yaml
+++ b/charts/docker-mailserver/templates/deployment.yaml
@@ -174,6 +174,8 @@ spec:
             - name: submission
               containerPort: 587
           {{- if .Values.proxyProtocol.enabled }}
+            - name: smtp-proxy
+              containerPort: 12525
             - name: subs-proxy
               containerPort: 10465
             - name: sub-proxy

--- a/charts/docker-mailserver/templates/service.yaml
+++ b/charts/docker-mailserver/templates/service.yaml
@@ -55,6 +55,9 @@ spec:
       nodePort: {{ default "30587" .Values.service.nodePort.submission }}
       {{ end }}
   {{- if .Values.proxyProtocol.enabled }}
+    - name: smtp-proxy
+      targetPort: smtp-proxy
+      port: 12525
     - name: subs-proxy
       targetPort: subs-proxy
       port: 10465

--- a/charts/docker-mailserver/values.yaml
+++ b/charts/docker-mailserver/values.yaml
@@ -576,6 +576,12 @@ configMaps:
         -o milter_macro_daemon_name=ORIGINATING
         -o cleanup_service_name=sender-cleanup
         -o smtpd_upstream_proxy_protocol=haproxy
+
+      # Smtp with proxy
+      12525     inet  n       -       n       -       1       postscreen
+        -o syslog_name=postfix/smtp-proxy
+        -o postscreen_upstream_proxy_protocol=haproxy
+        -o postscreen_cache_map=btree:$data_directory/postscreen_10025_cache
       EOS
       {{- end }}
 


### PR DESCRIPTION
Using port 12525 as described in [docker-mailserver documentation](https://github.com/docker-mailserver/docker-mailserver/blob/e370c0c96a28acfbd66b20ffac327528eda78104/docs/content/config/advanced/kubernetes.md?plain=1#L760) `due to a possible clash with Amavis`