### PR TITLE
Fixed indent issues

### DIFF
--- a/charts/docker-mailserver/Chart.yaml
+++ b/charts/docker-mailserver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "14.0.0"
 description: A fullstack but simple mailserver (smtp, imap, antispam, antivirus, ssl...) using Docker.
 name: docker-mailserver
-version: 4.0.0
+version: 4.0.2
 sources:
 - https://github.com/docker-mailserver/docker-mailserver-helm
 maintainers:

--- a/charts/docker-mailserver/templates/service.yaml
+++ b/charts/docker-mailserver/templates/service.yaml
@@ -11,17 +11,17 @@ metadata:
     prometheus.io/path: {{ .Values.monitoring.service.path | quote }}
     prometheus.io/port: {{ .Values.monitoring.service.port | quote }}
     ##  
-  {{- if .Values.service.annotations }}
-  {{ toYaml .Values.service.annotations | indent 2 }}  
-  {{ end }}    
+{{- if .Values.service.annotations }}
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{ end }}
   labels:
     app.kubernetes.io/name: {{ template "dockermailserver.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
-  {{- if .Values.service.labels }}
-  {{ toYaml .Values.service.labels | indent 2 }}  
-  {{ end }} 
+{{- if .Values.service.labels }}
+{{ toYaml .Values.service.labels | indent 4 }}
+{{ end }}
   name: {{ template "dockermailserver.fullname" . }}
 spec:
   ## If a load balancer is being used, ensure that the newer type of LB that passes along IP information is used


### PR DESCRIPTION
Using two annotations or two labels on the service field causes just the first one to be taken into account.