### PR TITLE
Added initContainers

### DIFF
--- a/charts/docker-mailserver/Chart.yaml
+++ b/charts/docker-mailserver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "14.0.0"
 description: A fullstack but simple mailserver (smtp, imap, antispam, antivirus, ssl...) using Docker.
 name: docker-mailserver
-version: 4.0.0
+version: 4.0.2
 sources:
 - https://github.com/docker-mailserver/docker-mailserver-helm
 maintainers:

--- a/charts/docker-mailserver/Chart.yaml
+++ b/charts/docker-mailserver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "14.0.0"
 description: A fullstack but simple mailserver (smtp, imap, antispam, antivirus, ssl...) using Docker.
 name: docker-mailserver
-version: 4.0.2
+version: 4.0.3
 sources:
 - https://github.com/docker-mailserver/docker-mailserver-helm
 maintainers:

--- a/charts/docker-mailserver/templates/deployment.yaml
+++ b/charts/docker-mailserver/templates/deployment.yaml
@@ -80,6 +80,29 @@ spec:
       {{- end }}
     {{- end }}
 
+        # Extra volumes
+      {{- with .Values.deployment.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      {{- with .Values.deployment.initContainers }}
+      initContainers:
+      {{- range . }}
+        - name: {{ .name }}
+          image: {{ .image }}
+          {{- with .command }}
+          command: {{ toYaml . | nindent 10 }}
+          {{- end }}
+          {{- with .args }}
+          args: {{ toYaml . | nindent 10 }}
+          {{- end }}
+          {{- with $.Values.deployment.extraVolumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- end }}
+      {{- end }}
+
       containers:
         - name: docker-mailserver
           image: {{ .Values.image.name }}:{{ default .Chart.AppVersion .Values.image.tag }}
@@ -146,6 +169,11 @@ spec:
               mountPath: {{ $persistence.mountPath }}
           {{- end }}
         {{- end }}
+
+            # Mount Extra Volumes
+          {{- with $.Values.deployment.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
 
           livenessProbe:
             exec:

--- a/charts/docker-mailserver/templates/deployment.yaml
+++ b/charts/docker-mailserver/templates/deployment.yaml
@@ -85,22 +85,11 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 
-      {{- with .Values.deployment.initContainers }}
+      {{- if .Values.deployment.initContainers }}
       initContainers:
-      {{- range . }}
-        - name: {{ .name }}
-          image: {{ .image }}
-          {{- with .command }}
-          command: {{ toYaml . | nindent 10 }}
-          {{- end }}
-          {{- with .args }}
-          args: {{ toYaml . | nindent 10 }}
-          {{- end }}
-          {{- with $.Values.deployment.extraVolumeMounts }}
-          volumeMounts:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-      {{- end }}
+        {{- with .Values.deployment.initContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
 
       containers:

--- a/charts/docker-mailserver/values.yaml
+++ b/charts/docker-mailserver/values.yaml
@@ -279,6 +279,9 @@ deployment:
   #    command: [sh, -c]
   #    args:
   #      - echo "Hello, world!" > /mnt/extra-storage/test
+  #    volumeMounts:
+  #      - name: extra-storage
+  #        mountPath: /mnt/extra-storage
 
   ## Optionally specify a list of extra mounts to add (normally used with extraVolumes)
   extraVolumeMounts: []

--- a/charts/docker-mailserver/values.yaml
+++ b/charts/docker-mailserver/values.yaml
@@ -272,6 +272,24 @@ deployment:
   ## Optionally specify tolerations for the deployment
   tolerations: []
 
+  ## Optionally specify initContainers
+  initContainers: []
+  #  - name: init
+  #    image: alpine:3
+  #    command: [sh, -c]
+  #    args:
+  #      - echo "Hello, world!" > /mnt/extra-storage/test
+
+  ## Optionally specify a list of extra mounts to add (normally used with extraVolumes)
+  extraVolumeMounts: []
+  #  - name: extra-storage
+  #    mountPath: /mnt/extra-storage
+
+  ## Optionally specify a list of extra volumes to add
+  extraVolumes: []
+  #  - name: extra-storage
+  #    emptyDir: {}
+
 service:
   ## What scope the service should be exposed in. One of:
   ## - LoadBalancer (to the world)


### PR DESCRIPTION
Added `initContainers` (with `extraVolumes` and `extraVolumeMounts` fields). Also closes: #114.

These fields are need if for example one uses custom CA authority (Step Certificates) and needs to set a custom certificate that needs to be stored in `/etc/ssl/certs/`. Using an init container, one can mount the certificates to the given folder and run the `update-ca-certificates` command.