### PR TITLE
Configure tcp routing from ingress to the service

### DIFF
--- a/charts/docker-mailserver/Chart.yaml
+++ b/charts/docker-mailserver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "14.0.0"
 description: A fullstack but simple mailserver (smtp, imap, antispam, antivirus, ssl...) using Docker.
 name: docker-mailserver
-version: 4.0.1
+version: 4.0.2
 sources:
 - https://github.com/docker-mailserver/docker-mailserver-helm
 maintainers:

--- a/charts/docker-mailserver/templates/ingress-nginx.yaml
+++ b/charts/docker-mailserver/templates/ingress-nginx.yaml
@@ -1,0 +1,20 @@
+{{- if and (eq .Values.service.type "ClusterIP")
+(.Values.proxyProtocol.enabled)
+(eq .Values.ingressClassName "nginx")
+-}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tcp-services
+  namespace: ingress-nginx
+data:
+  25:  {{ .Release.Namespace }}/{{ template "dockermailserver.fullname" . }}:25
+  465: {{ .Release.Namespace }}/{{ template "dockermailserver.fullname" . }}:465
+  587: {{ .Release.Namespace }}/{{ template "dockermailserver.fullname" . }}:587
+{{- if and (.Values.deployment.env.ENABLE_IMAP) (not .Values.deployment.env.SMTP_ONLY) }}
+  993: {{ .Release.Namespace }}/{{ template "dockermailserver.fullname" . }}:993
+{{- end }}
+{{- if and (.Values.deployment.env.ENABLE_POP3) (not .Values.deployment.env.SMTP_ONLY) }}
+  995: {{ .Release.Namespace }}/{{ template "dockermailserver.fullname" . }}:995
+{{- end }}
+{{- end }}

--- a/charts/docker-mailserver/templates/ingress-traefik.yaml
+++ b/charts/docker-mailserver/templates/ingress-traefik.yaml
@@ -1,0 +1,92 @@
+{{- if and (eq .Values.service.type "ClusterIP")
+(.Values.proxyProtocol.enabled)
+(eq .Values.ingressClassName "traefik")
+-}}
+apiVersion: traefik.io/v1alpha1
+kind: IngressRouteTCP
+
+metadata:
+  name: smtp
+
+spec:
+  entryPoints: [ smtp ]
+  routes:
+    - match: HostSNI(`*`)
+      services:
+        - name: {{ template "dockermailserver.fullname" . }}
+          port: smtp-proxy # note the 15 character limit here
+          proxyProtocol:
+            version: 2
+
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRouteTCP
+
+metadata:
+  name: submission
+
+spec:
+  entryPoints: [ submission ]
+  routes:
+    - match: HostSNI(`*`)
+      services:
+        - name: {{ template "dockermailserver.fullname" . }}
+          port: sub-proxy # note the 15 character limit here
+          proxyProtocol:
+            version: 2
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRouteTCP
+
+metadata:
+  name: submissions
+
+spec:
+  entryPoints: [ submissions ]
+  routes:
+    - match: HostSNI(`*`)
+      services:
+        - name: {{ template "dockermailserver.fullname" . }}
+          port: subs-proxy # note the 15 character limit here
+          proxyProtocol:
+            version: 2
+
+{{- if and (.Values.deployment.env.ENABLE_IMAP) (not .Values.deployment.env.SMTP_ONLY) }}
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRouteTCP
+
+metadata:
+  name: imaps
+
+spec:
+  entryPoints: [ imaps ]
+  routes:
+    - match: HostSNI(`*`)
+      services:
+        - name: {{ template "dockermailserver.fullname" . }}
+          port: imaps-proxy
+          proxyProtocol:
+            version: 2
+
+{{- end }}
+{{- if and (.Values.deployment.env.ENABLE_POP3) (not .Values.deployment.env.SMTP_ONLY) }}
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRouteTCP
+
+metadata:
+  name: pop3s
+
+spec:
+  entryPoints: [ pop3s ]
+  routes:
+    - match: HostSNI(`*`)
+      services:
+        - name: {{ template "dockermailserver.fullname" . }}
+          port: pop3s-proxy
+          proxyProtocol:
+            version: 2
+{{- end }}
+
+{{- end }}

--- a/charts/docker-mailserver/values.yaml
+++ b/charts/docker-mailserver/values.yaml
@@ -298,6 +298,9 @@ service:
   annotations: {}
   labels: {}
 
+# IngressClass to define TCP routing with service.type = "ClusterIP" & ProxyProtocol enabled
+ingressClassName: nginx
+
 # Note this is a dictionary and not a list so invidual keys can be overriden by --set or --value helm parameters
 persistence:
   # Stores generated configuration files


### PR DESCRIPTION
This is related to #121.

In case ClusterIP is used, the service could be exposed using the ingress controller router.
These configurations are defined on the following [link,](https://docker-mailserver.github.io/docker-mailserver/latest/config/advanced/kubernetes/#exposing-your-mail-server-to-the-outside-world) section -> "using the PROXY Protocol" and "Configure the ingress controller"


I'm currently using traefik, I couldn't find a way to test the nginx configurations, the definition is based on what the docs mention.