### PR TITLE
fix(docs): Correct syntax for specifying secrets

### DIFF
--- a/charts/docker-mailserver/Chart.yaml
+++ b/charts/docker-mailserver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "14.0.0"
 description: A fullstack but simple mailserver (smtp, imap, antispam, antivirus, ssl...) using Docker.
 name: docker-mailserver
-version: 4.0.5
+version: 4.0.6
 sources:
 - https://github.com/docker-mailserver/docker-mailserver-helm
 maintainers:

--- a/charts/docker-mailserver/values.yaml
+++ b/charts/docker-mailserver/values.yaml
@@ -611,15 +611,17 @@ configMaps:
 ## such as DKIM signing keys.
 ##
 ##  secrets:
-##  - name: rspamd.example.com                      # This is the name of the Secret
-##    create: true                                  # If true, create a new Secret
-##    path: rspamd.dkim.rsa-2048-mail-example.com.private.txt
-##    data: abace                           # If create is true, then you must specify content. Must be base 64 encoded!
+##    rspamd.example.com:
+##      name: rspamd.example.com                      # This is the name of the Secret
+##      create: true                                  # If true, create a new Secret
+##      path: rspamd.dkim.rsa-2048-mail-example.com.private.txt
+##      data: abace                           # If create is true, then you must specify content. Must be base 64 encoded!
 ##
-##  - name: rspamd.dkim.rsa-2048-mail-example.com.public
-##    create: true
-##    path: rspamd/dkim/rsa-2048-mail-example.com.public
-##    data: abace                           # If create is true, then you must specify content. Must be base 64 encoded!
+##    rspamd.dkim.rsa-2048-mail-example.com.public:
+##      name: rspamd.dkim.rsa-2048-mail-example.com.public
+##      create: true
+##      path: rspamd/dkim/rsa-2048-mail-example.com.public
+##      data: abace                           # If create is true, then you must specify content. Must be base 64 encoded!
 ##
 ##  If you set the create key to false, then you must manually create the ConfigMaps before deploying the chart.
 ##


### PR DESCRIPTION
The existing example how how to specify a secret is wrong: in the deployment template, it expects secret to be a key-value pair and not an array. To preserve backwards compatibility for whomever has figured this out already and worked around it, I've adjusted the example to be an overly verbose key-value pair instead of updating the deployment template to work with an array.