### PR TITLE
secret env vars

### DIFF
--- a/charts/docker-mailserver/Chart.yaml
+++ b/charts/docker-mailserver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "14.0.0"
 description: A fullstack but simple mailserver (smtp, imap, antispam, antivirus, ssl...) using Docker.
 name: docker-mailserver
-version: 4.0.7
+version: 4.1.0
 sources:
 - https://github.com/docker-mailserver/docker-mailserver-helm
 maintainers:

--- a/charts/docker-mailserver/templates/deployment.yaml
+++ b/charts/docker-mailserver/templates/deployment.yaml
@@ -102,8 +102,12 @@ spec:
           env:
           {{- range $pkey, $pval := .Values.deployment.env }}
           - name: {{ $pkey }}
+            {{- if kindIs "map" $pval }}
+            {{- toYaml $pval | nindent 12 }}
+            {{- else }}
             value: {{ quote $pval }}
-          {{- end }} 
+            {{- end }}
+          {{- end }}
 
           {{- if .Values.certificate }}
           - name: SSL_TYPE
@@ -112,6 +116,14 @@ spec:
             value: /tmp/dms/custom-certs/tls.crt
           - name: SSL_KEY_PATH
             value: /tmp/dms/custom-certs/tls.key
+          {{- end }}
+
+          {{- if .Values.deployment.secretEnvironments }}
+          envFrom:
+          {{- range .Values.deployment.secretEnvironments }}
+          - secretRef:
+              name: {{ . | quote }}
+          {{- end }}
           {{- end }}
 
           resources:


### PR DESCRIPTION
This PR allows for specifying secret env vars by either

- mounting an entire secret(s) via `envFrom`

  ```yaml
  deployment:
    secretEnvironments:
      - secret1
      - secret2
  ```

- projecting specific secrets allowing eg. `valueFrom` in container's `env` stanza. An existing env value is preserved as is, but it is also allowed to be a `map`, ie. an invalid scalar value but a valid projection config:

  ```yaml
  deployment:
    env:
      ACCOUNT_PROVISIONER: LDAP
      LDAP_SERVER_HOST: ldap://openldap
      LDAP_BIND_DN: cn=admin,dc=ldap
      LDAP_BIND_PW:
        valueFrom:
          secretKeyRef:
            name: mailserver
            key: LDAP_BIND_PW
  ```


everything is backwards compatible, so completely inobtrusive for existing deployments

hope this helps, ciao!