### PR TITLE
Update line numbers in links in README.md

### DIFF
--- a/charts/docker-mailserver/Chart.yaml
+++ b/charts/docker-mailserver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "14.0.0"
 description: A fullstack but simple mailserver (smtp, imap, antispam, antivirus, ssl...) using Docker.
 name: docker-mailserver
-version: 4.1.1
+version: 4.1.2
 sources:
 - https://github.com/docker-mailserver/docker-mailserver-helm
 maintainers:

--- a/charts/docker-mailserver/README.md
+++ b/charts/docker-mailserver/README.md
@@ -98,11 +98,11 @@ Configuration files are stored on a Kubernetes [volume](#persistence) mounted at
 
 ### ConfigMaps
 
-Its is also possible to use ConfigMaps to mount configuration files in the container. This is done by adding to  the `configFiles` key in a custom `values.yaml` file. For more information please see the [documentation](./values.yaml#L425) in values.yaml
+Its is also possible to use ConfigMaps to mount configuration files in the container. This is done by adding to  the `configFiles` key in a custom `values.yaml` file. For more information please see the [documentation](./values.yaml#L453) in values.yaml
 
 ### Secrets
 
-Secrets can also be used to mount configuration files in the container. For example, dkim keys could be stored in a secret as opposed to a file in the `mail-config` volume. Once again, for more information please see the [documentation](./values.yaml#L600) in values.yaml
+Secrets can also be used to mount configuration files in the container. For example, dkim keys could be stored in a secret as opposed to a file in the `mail-config` volume. Once again, for more information please see the [documentation](./values.yaml#L610) in values.yaml
 
 ## Values YAML
 


### PR DESCRIPTION
The links to the documentation in Values.yaml should link to the correct line numbers 