### PR TITLE
Fix service template to set ClusterIP

### DIFF
--- a/charts/docker-mailserver/templates/service.yaml
+++ b/charts/docker-mailserver/templates/service.yaml
@@ -137,3 +137,6 @@ spec:
     {{- end }}
 
   type: {{ default "ClusterIP" .Values.service.type }}
+  {{- if .Values.service.clusterIp }}
+  clusterIP: {{ .Values.service.clusterIp }}
+  {{- end }}

--- a/charts/docker-mailserver/templates/service.yaml
+++ b/charts/docker-mailserver/templates/service.yaml
@@ -137,12 +137,3 @@ spec:
     {{- end }}
 
   type: {{ default "ClusterIP" .Values.service.type }}
-  {{- if eq .Values.service.type "LoadBalancer" }}
-    {{- if .Values.service.loadBalancer.publicIp }}
-  loadBalancerIP: {{ .Values.service.loadBalancer.publicIp }}
-      {{- if .Values.service.loadBalancer.allowedIps }}
-  loadBalancerSourceRanges:
-  {{ .Values.service.loadBalancer.allowedIps | toYaml | indent 4 }}
-      {{- end }}
-    {{- end }}
-  {{- end }}

--- a/charts/docker-mailserver/values.yaml
+++ b/charts/docker-mailserver/values.yaml
@@ -304,17 +304,6 @@ service:
   ##       to allocate a free IP from the pool.
   ## Default: Automatically assign a random IP
   # privateIp:
-  ## Only relevant if the `type` above is "LoadBalancer"
-  loadBalancer:
-    ## If there is already a reserved public IP that this load balancer should use, indicate it here.
-    ## Default: Automatically assign a random, ephemeral IP
-    # publicIp:
-    ## If there should be firewall rules restricting the load balancer to a limited set of IPs, specify those IPs below
-    ## in CIDR format. If all IPs should be allowed access, set the CIDR as "0.0.0.0/0"
-    allowedIps:
-      - "0.0.0.0/0"
-    ## If there is a Hostname associated with this site, add it here and it will be rendered in the documentation.
-    # hostName:
   annotations: {}
   labels: {}
 

--- a/charts/docker-mailserver/values.yaml
+++ b/charts/docker-mailserver/values.yaml
@@ -303,7 +303,7 @@ service:
   ## Note: It's quite unlikely that an IP should be specific. Normally, the best thing to do is leave it to Kubernetes
   ##       to allocate a free IP from the pool.
   ## Default: Automatically assign a random IP
-  # privateIp:
+  # clusterIp:
   annotations: {}
   labels: {}
 


### PR DESCRIPTION
In the chart's `values.yaml`, there's a commented out property called [`service.privateIp`](https://github.com/docker-mailserver/docker-mailserver-helm/blob/master/charts/docker-mailserver/values.yaml#L306), which seems to be intended for setting a fixed IP address for the service. Its values wasn't used in the service template however, so I've added it for the `ClusterIP` type and verified the change on my local cluster.