### PR TITLE
syslog name for SMTP w/ proxy changed to postfix/smtpd-proxy

### DIFF
--- a/charts/docker-mailserver/tests/__snapshot__/configmap_test.yaml.snap
+++ b/charts/docker-mailserver/tests/__snapshot__/configmap_test.yaml.snap
@@ -88,7 +88,7 @@ manifest should match snapshot:
 
         # Smtp with proxy
         12525     inet  n       -       n       -       1       postscreen
-          -o syslog_name=postfix/smtp-proxy
+          -o syslog_name=postfix/smtpd-proxy
           -o postscreen_upstream_proxy_protocol=haproxy
           -o postscreen_cache_map=btree:$data_directory/postscreen_10025_cache
         EOS

--- a/charts/docker-mailserver/values.yaml
+++ b/charts/docker-mailserver/values.yaml
@@ -623,7 +623,7 @@ configMaps:
 
       # Smtp with proxy
       12525     inet  n       -       n       -       1       postscreen
-        -o syslog_name=postfix/smtp-proxy
+        -o syslog_name=postfix/smtpd-proxy
         -o postscreen_upstream_proxy_protocol=haproxy
         -o postscreen_cache_map=btree:$data_directory/postscreen_10025_cache
       EOS


### PR DESCRIPTION
@polarathene says the `syslog_name` should be `postfix/smtp-proxy` (https://github.com/orgs/docker-mailserver/discussions/4503#discussioncomment-13404308) and that matches what's said in https://serverfault.com/questions/696936/whats-the-difference-between-postfix-smtp-and-postfix-smtpd