### PR TITLE
Uses sed to copy and modify ports to create PROXY Protocol ports

### DIFF
--- a/charts/docker-mailserver/README.md
+++ b/charts/docker-mailserver/README.md
@@ -197,13 +197,13 @@ This can get a bit complicated, as explained in the `docker-mailserver` [documen
 
 One approach to preserving the client IP address is to use the PROXY protocol, which is explained in the [documentation](https://docker-mailserver.github.io/docker-mailserver/latest/config/advanced/kubernetes/#proxy-port-to-service-via-proxy-protocol).
 
-The Helm chart supports the use of the proxy protocol via the `proxyProtocol` key. To enable it set the `proxyProtocol.enable` key to true. You will also want to set the `trustedNetworks` key.
+The Helm chart supports the use of the proxy protocol via the `proxyProtocol` key. By default `proxyProtocol.enable` is true, and `trustedNetworks` is set to the private IP network ranges, as are typically used inside a cluster.
 
 ```yaml
 proxyProtocol:
   enabled: true
   # List of sources (in CIDR format, space-separated) to permit PROXY protocol from
-  trustedNetworks: "10.0.0.0/8 192.168.0.0/16 172.16.0.0/16"
+  trustedNetworks: "10.0.0.0/8 192.168.0.0/16 172.16.0.0/12"
 ```
 
 Enabling the PROXY protocol will create an additional port for each protocol (by adding 10,000 to the standard port value) that is configured to understand the PROXY protocol. Thus:

--- a/charts/docker-mailserver/README.md
+++ b/charts/docker-mailserver/README.md
@@ -117,6 +117,8 @@ cat /tmp/docker-mailserver/postfix-accounts.cf
 
 This path is [mapped](#persistence) to a Kubernetes Volume.
 
+Optionally (but reccomended), create a [`NetworkPolicy`](https://kubernetes.io/docs/concepts/services-networking/network-policies/) that only allows appropriate pods to connect to the DMS pod.
+
 ## Configuration
 
 Assuming you still have a command prompt [open](#getting-started) in the running container, run the setup command to see additional configuration options:
@@ -206,16 +208,20 @@ proxyProtocol:
   trustedNetworks: "10.0.0.0/8 192.168.0.0/16 172.16.0.0/12"
 ```
 
+For security, you should narrow this to the actual range of IP addresses used by your ingress controller pods, and be certain to exclude any IP ranges gatewayed from IPv6 to v4 or vice versa.
+Also note that any compromised container in the cluster could use the PROXY protocol to evade some security measures, so set a `NetworkPolicy` that only allows the appropriate pods to connect to the DMS pod.
+
 Enabling the PROXY protocol will create an additional port for each protocol (by adding 10,000 to the standard port value) that is configured to understand the PROXY protocol. Thus:
 
-| Protocol    |  Port   |  PROXY Port |
-| ----------  | ------- | ----------- |
-| submissions |   465   |    10465    |
-| submission  |   587   |    10587    |
-| imap        |   143   |    10143    |
-| imaps       |   993   |    10993    |
-| pop3        |   110   |    10110    |
-| pop3s       |   995   |    10995    |
+| Protocol    | Regular Port | PROXY Protocol Port |
+| ----------  |--------------|---------------------|
+| smtp        | 25           | 12525               |
+| submissions | 465          | 10465               |
+| submission  | 587          | 10587               |
+| imap        | 143          | 10143               |
+| imaps       | 993          | 10993               |
+| pop3        | 110          | 10110               |
+| pop3s       | 995          | 10995               |
 
 If you do not enable the PROXY protocol and your mail server is not exposed using a load-balancer service with an external traffic policy in "Local" mode, then all incoming mail traffic will look like it comes from a local Kubernetes cluster IP.
 

--- a/charts/docker-mailserver/tests/__snapshot__/configmap_test.yaml.snap
+++ b/charts/docker-mailserver/tests/__snapshot__/configmap_test.yaml.snap
@@ -64,7 +64,7 @@ manifest should match snapshot:
         # Create a variant for port 25 too (NOTE: Port 10025 is already assigned in DMS to Amavis):
         postconf -Mf smtp/inet | sed -e s/^smtp/12525/ >> /etc/postfix/master.cf
         # Enable PROXY Protocol support (different setting as port 25 is handled via postscreen), optionally configure a `syslog_name` to distinguish in logs:
-        postconf -P 12525/inet/postscreen_upstream_proxy_protocol=haproxy 12525/inet/postscreen_cache_map=proxy:btree:$data_directory/postscreen_12525_cache 12525/inet/syslog_name=postfix/smtp-proxyprotocol
+        postconf -P 12525/inet/postscreen_upstream_proxy_protocol=haproxy 12525/inet/postscreen_cache_map=proxy:btree:\$data_directory/postscreen_12525_cache 12525/inet/syslog_name=postfix/smtpd-proxyprotocol
     kind: ConfigMap
     metadata:
       labels:

--- a/charts/docker-mailserver/tests/__snapshot__/configmap_test.yaml.snap
+++ b/charts/docker-mailserver/tests/__snapshot__/configmap_test.yaml.snap
@@ -14,13 +14,13 @@ manifest should match snapshot:
                 ssl = yes
             }
 
-            inet_listener imap_proxy {
+            inet_listener imap_proxyprotocol {
                 haproxy = yes
                 port = 10143
                 ssl = no
             }
 
-            inet_listener imaps_proxy {
+            inet_listener imaps_proxyprotocol {
                 haproxy = yes
                 port = 10993
                 ssl = yes
@@ -51,47 +51,17 @@ manifest should match snapshot:
     data:
       user-patches.sh: |
         #!/bin/bash
-        # Make sure to keep this file in sync with https://github.com/docker-mailserver/docker-mailserver/blob/master/target/postfix/master.cf!
-        cat <<EOS >> /etc/postfix/master.cf
+        # Duplicate the config for the submission(s) service ports (587 / 465) with adjustments for the PROXY ports (10587 / 10465) and `syslog_name` setting:
+        postconf -Mf submission/inet | sed -e s/^submission/10587/ -e 's/submission/submission-proxyprotocol/' >> /etc/postfix/master.cf
+        postconf -Mf submissions/inet | sed -e s/^submissions/10465/ -e 's/submissions/submissions-proxyprotocol/' >> /etc/postfix/master.cf
+        # Enable PROXY Protocol support for these new service variants:
+        postconf -P 10587/inet/smtpd_upstream_proxy_protocol=haproxy
+        postconf -P 10465/inet/smtpd_upstream_proxy_protocol=haproxy
 
-        # Submission with proxy
-        10587     inet  n       -       n       -       -       smtpd
-          -o syslog_name=postfix/submission
-          -o smtpd_tls_security_level=encrypt
-          -o smtpd_sasl_auth_enable=yes
-          -o smtpd_sasl_type=dovecot
-          -o smtpd_reject_unlisted_recipient=no
-          -o smtpd_sasl_authenticated_header=yes
-          -o smtpd_client_restrictions=permit_sasl_authenticated,reject
-          -o smtpd_relay_restrictions=permit_sasl_authenticated,reject
-          -o smtpd_sender_restrictions=\$mua_sender_restrictions
-          -o smtpd_discard_ehlo_keywords=
-          -o milter_macro_daemon_name=ORIGINATING
-          -o cleanup_service_name=sender-cleanup
-          -o smtpd_upstream_proxy_protocol=haproxy
-
-        # Submissions with proxy
-        10465     inet  n       -       n       -       -       smtpd
-          -o syslog_name=postfix/submissions
-          -o smtpd_tls_wrappermode=yes
-          -o smtpd_sasl_auth_enable=yes
-          -o smtpd_sasl_type=dovecot
-          -o smtpd_reject_unlisted_recipient=no
-          -o smtpd_sasl_authenticated_header=yes
-          -o smtpd_client_restrictions=permit_sasl_authenticated,reject
-          -o smtpd_relay_restrictions=permit_sasl_authenticated,reject
-          -o smtpd_sender_restrictions=\$mua_sender_restrictions
-          -o smtpd_discard_ehlo_keywords=
-          -o milter_macro_daemon_name=ORIGINATING
-          -o cleanup_service_name=sender-cleanup
-          -o smtpd_upstream_proxy_protocol=haproxy
-
-        # Smtp with proxy
-        12525     inet  n       -       n       -       1       postscreen
-          -o syslog_name=postfix/smtpd-proxy
-          -o postscreen_upstream_proxy_protocol=haproxy
-          -o postscreen_cache_map=btree:$data_directory/postscreen_10025_cache
-        EOS
+        # Create a variant for port 25 too (NOTE: Port 10025 is already assigned in DMS to Amavis):
+        postconf -Mf smtp/inet | sed -e s/^smtp/12525/ >> /etc/postfix/master.cf
+        # Enable PROXY Protocol support (different setting as port 25 is handled via postscreen), optionally configure a `syslog_name` to distinguish in logs:
+        postconf -P 12525/inet/postscreen_upstream_proxy_protocol=haproxy 12525/inet/postscreen_cache_map=proxy:btree:$data_directory/postscreen_12525_cache 12525/inet/syslog_name=postfix/smtp-proxyprotocol
     kind: ConfigMap
     metadata:
       labels:

--- a/charts/docker-mailserver/tests/__snapshot__/configmap_test.yaml.snap
+++ b/charts/docker-mailserver/tests/__snapshot__/configmap_test.yaml.snap
@@ -51,6 +51,9 @@ manifest should match snapshot:
     data:
       user-patches.sh: |
         #!/bin/bash
+        # NOTE: Keep in sync with upstream advice:
+        # https://github.com/docker-mailserver/docker-mailserver/blob/v15.0.0/docs/content/examples/tutorials/mailserver-behind-proxy.md?plain=1#L238-L268
+
         # Duplicate the config for the submission(s) service ports (587 / 465) with adjustments for the PROXY ports (10587 / 10465) and `syslog_name` setting:
         postconf -Mf submission/inet | sed -e s/^submission/10587/ -e 's/submission/submission-proxyprotocol/' >> /etc/postfix/master.cf
         postconf -Mf submissions/inet | sed -e s/^submissions/10465/ -e 's/submissions/submissions-proxyprotocol/' >> /etc/postfix/master.cf

--- a/charts/docker-mailserver/values.yaml
+++ b/charts/docker-mailserver/values.yaml
@@ -495,13 +495,13 @@ configMaps:
                 ssl = yes
             }
 
-            inet_listener imap_proxy {
+            inet_listener imap_proxyprotocol {
                 haproxy = yes
                 port = 10143
                 ssl = no
             }
 
-            inet_listener imaps_proxy {
+            inet_listener imaps_proxyprotocol {
                 haproxy = yes
                 port = 10993
                 ssl = yes
@@ -520,13 +520,13 @@ configMaps:
                 ssl = yes
             }
 
-            inet_listener pop3_proxy {
+            inet_listener pop3_proxyprotocol {
                 haproxy = yes
                 port = 10110
                 ssl = no
             }
 
-            inet_listener pop3s_proxy {
+            inet_listener pop3s_proxyprotocol {
                 haproxy = yes
                 port = 10995
                 ssl = yes
@@ -540,7 +540,7 @@ configMaps:
                 port = 4190
             }
 
-            inet_listener sieve_proxy {
+            inet_listener sieve_proxyprotocol {
                 port = 14190
             }
         }
@@ -578,47 +578,17 @@ configMaps:
       #!/bin/bash
 
       {{- if .Values.proxyProtocol.enabled }}
-      # Make sure to keep this file in sync with https://github.com/docker-mailserver/docker-mailserver/blob/master/target/postfix/master.cf!
-      cat <<EOS >> /etc/postfix/master.cf
-
-      # Submission with proxy
-      10587     inet  n       -       n       -       -       smtpd
-        -o syslog_name=postfix/submission
-        -o smtpd_tls_security_level=encrypt
-        -o smtpd_sasl_auth_enable=yes
-        -o smtpd_sasl_type=dovecot
-        -o smtpd_reject_unlisted_recipient=no
-        -o smtpd_sasl_authenticated_header=yes
-        -o smtpd_client_restrictions=permit_sasl_authenticated,reject
-        -o smtpd_relay_restrictions=permit_sasl_authenticated,reject
-        -o smtpd_sender_restrictions=\$mua_sender_restrictions
-        -o smtpd_discard_ehlo_keywords=
-        -o milter_macro_daemon_name=ORIGINATING
-        -o cleanup_service_name=sender-cleanup
-        -o smtpd_upstream_proxy_protocol=haproxy
-
-      # Submissions with proxy
-      10465     inet  n       -       n       -       -       smtpd
-        -o syslog_name=postfix/submissions
-        -o smtpd_tls_wrappermode=yes
-        -o smtpd_sasl_auth_enable=yes
-        -o smtpd_sasl_type=dovecot
-        -o smtpd_reject_unlisted_recipient=no
-        -o smtpd_sasl_authenticated_header=yes
-        -o smtpd_client_restrictions=permit_sasl_authenticated,reject
-        -o smtpd_relay_restrictions=permit_sasl_authenticated,reject
-        -o smtpd_sender_restrictions=\$mua_sender_restrictions
-        -o smtpd_discard_ehlo_keywords=
-        -o milter_macro_daemon_name=ORIGINATING
-        -o cleanup_service_name=sender-cleanup
-        -o smtpd_upstream_proxy_protocol=haproxy
-
-      # Smtp with proxy
-      12525     inet  n       -       n       -       1       postscreen
-        -o syslog_name=postfix/smtpd-proxy
-        -o postscreen_upstream_proxy_protocol=haproxy
-        -o postscreen_cache_map=btree:$data_directory/postscreen_10025_cache
-      EOS
+      # Duplicate the config for the submission(s) service ports (587 / 465) with adjustments for the PROXY ports (10587 / 10465) and `syslog_name` setting:
+      postconf -Mf submission/inet | sed -e s/^submission/10587/ -e 's/submission/submission-proxyprotocol/' >> /etc/postfix/master.cf
+      postconf -Mf submissions/inet | sed -e s/^submissions/10465/ -e 's/submissions/submissions-proxyprotocol/' >> /etc/postfix/master.cf
+      # Enable PROXY Protocol support for these new service variants:
+      postconf -P 10587/inet/smtpd_upstream_proxy_protocol=haproxy
+      postconf -P 10465/inet/smtpd_upstream_proxy_protocol=haproxy
+      
+      # Create a variant for port 25 too (NOTE: Port 10025 is already assigned in DMS to Amavis):
+      postconf -Mf smtp/inet | sed -e s/^smtp/12525/ >> /etc/postfix/master.cf
+      # Enable PROXY Protocol support (different setting as port 25 is handled via postscreen), optionally configure a `syslog_name` to distinguish in logs:
+      postconf -P 12525/inet/postscreen_upstream_proxy_protocol=haproxy 12525/inet/postscreen_cache_map=proxy:btree:$data_directory/postscreen_12525_cache 12525/inet/syslog_name=postfix/smtp-proxyprotocol
       {{- end }}
 
 ## The secrets key works the same way as the configs key. Use secrets to store sensitive information,

--- a/charts/docker-mailserver/values.yaml
+++ b/charts/docker-mailserver/values.yaml
@@ -578,6 +578,9 @@ configMaps:
       #!/bin/bash
 
       {{- if .Values.proxyProtocol.enabled }}
+      # NOTE: Keep in sync with upstream advice:
+      # https://github.com/docker-mailserver/docker-mailserver/blob/v15.0.0/docs/content/examples/tutorials/mailserver-behind-proxy.md?plain=1#L238-L268
+
       # Duplicate the config for the submission(s) service ports (587 / 465) with adjustments for the PROXY ports (10587 / 10465) and `syslog_name` setting:
       postconf -Mf submission/inet | sed -e s/^submission/10587/ -e 's/submission/submission-proxyprotocol/' >> /etc/postfix/master.cf
       postconf -Mf submissions/inet | sed -e s/^submissions/10465/ -e 's/submissions/submissions-proxyprotocol/' >> /etc/postfix/master.cf

--- a/charts/docker-mailserver/values.yaml
+++ b/charts/docker-mailserver/values.yaml
@@ -591,7 +591,7 @@ configMaps:
       # Create a variant for port 25 too (NOTE: Port 10025 is already assigned in DMS to Amavis):
       postconf -Mf smtp/inet | sed -e s/^smtp/12525/ >> /etc/postfix/master.cf
       # Enable PROXY Protocol support (different setting as port 25 is handled via postscreen), optionally configure a `syslog_name` to distinguish in logs:
-      postconf -P 12525/inet/postscreen_upstream_proxy_protocol=haproxy 12525/inet/postscreen_cache_map=proxy:btree:$data_directory/postscreen_12525_cache 12525/inet/syslog_name=postfix/smtp-proxyprotocol
+      postconf -P 12525/inet/postscreen_upstream_proxy_protocol=haproxy 12525/inet/postscreen_cache_map=proxy:btree:\$data_directory/postscreen_12525_cache 12525/inet/syslog_name=postfix/smtpd-proxyprotocol
       {{- end }}
 
 ## The secrets key works the same way as the configs key. Use secrets to store sensitive information,


### PR DESCRIPTION
This produces a `/etc/postfix/master.cf` file with only these differences from the current version:

```
78,79d77
< 
< # Submission with proxy
81c79
<   -o syslog_name=postfix/submission
---
>     -o syslog_name=postfix/submission-proxyprotocol
94,95d91
< 
< # Submissions with proxy
97c93
<   -o syslog_name=postfix/submissions
---
>     -o syslog_name=postfix/submissions-proxyprotocol
110,111d105
< 
< # Smtp with proxy
113d106
<   -o syslog_name=postfix/smtpd-proxy
115c108,109
<   -o postscreen_cache_map=btree:/postscreen_10025_cache
---
>     -o postscreen_cache_map=proxy:btree:$data_directory/postscreen_12525_cache
>     -o syslog_name=postfix/smtpd-proxyprotocol
```

Fixes #173 

References:

    https://github.com/docker-mailserver/docker-mailserver-helm/pull/156#issuecomment-2814036639 + https://github.com/docker-mailserver/docker-mailserver-helm/pull/172#discussion_r2136949187 PR feedback comments.
    Postscreen ports 25 + 12525 should be configured to share a cache map: 

https://github.com/docker-mailserver/docker-mailserver/pull/4066 ([additional ref](https://github.com/orgs/docker-mailserver/discussions/4503#discussioncomment-13435096))
[v15 Docs reference](https://github.com/docker-mailserver/docker-mailserver/blob/0c3aff21ffbb7990f0ad307d03c0c3180ee3756e/docs/content/examples/tutorials/mailserver-behind-proxy.md?plain=1#L238-L268) ([rendered page](https://docker-mailserver.github.io/docker-mailserver/latest/examples/tutorials/mailserver-behind-proxy/#dms-postfix-dovecot))
https://github.com/docker-mailserver/docker-mailserver/issues/3866#issuecomment-2807748711 to simplify this process.


