### PR TITLE
feat: Add spec.trafficDistribution field for service

### DIFF
--- a/charts/docker-mailserver/templates/service.yaml
+++ b/charts/docker-mailserver/templates/service.yaml
@@ -145,3 +145,6 @@ spec:
   {{- if .Values.service.clusterIp }}
   clusterIP: {{ .Values.service.clusterIp }}
   {{- end }}
+  {{- if .Values.service.trafficDistribution }}
+  trafficDistribution: {{ .Values.service.trafficDistribution }}
+  {{- end }}

--- a/charts/docker-mailserver/values.yaml
+++ b/charts/docker-mailserver/values.yaml
@@ -301,8 +301,9 @@ service:
   ## unless you have a good reason not to.
   # externalTrafficPolicy: "Cluster"
   ## Traffic distribution preference for Services. One of:
-  ## - PreferClose (routes traffic to endpoints that are topologically proximate)
-  ## Traffic distribution for multi-zone topology (Kubernetes 1.31+)
+  ## - PreferSameZone
+  ## - PreferSameNode
+  ## Ref: https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution
   trafficDistribution: ""
   ## If there is a port associated with a given service, expose it here.
   # port:

--- a/charts/docker-mailserver/values.yaml
+++ b/charts/docker-mailserver/values.yaml
@@ -302,8 +302,7 @@ service:
   # externalTrafficPolicy: "Cluster"
   ## Traffic distribution preference for Services. One of:
   ## - PreferClose (routes traffic to endpoints that are topologically proximate)
-  ## This field requires Kubernetes 1.31+ and is only available when the feature gate is enabled.
-  ## See: https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution
+  ## Traffic distribution for multi-zone topology (Kubernetes 1.31+)
   trafficDistribution: ""
   ## If there is a port associated with a given service, expose it here.
   # port:

--- a/charts/docker-mailserver/values.yaml
+++ b/charts/docker-mailserver/values.yaml
@@ -300,6 +300,11 @@ service:
   ## Set it to "Local" when used with type "LoadBalancer" and set it to "Cluster" when used with "NodePort",
   ## unless you have a good reason not to.
   # externalTrafficPolicy: "Cluster"
+  ## Traffic distribution preference for Services. One of:
+  ## - PreferClose (routes traffic to endpoints that are topologically proximate)
+  ## This field requires Kubernetes 1.31+ and is only available when the feature gate is enabled.
+  ## See: https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution
+  trafficDistribution: ""
   ## If there is a port associated with a given service, expose it here.
   # port:
   ## If there is a particular IP that should be used for the service, specify it here.

--- a/charts/docker-mailserver/values.yaml
+++ b/charts/docker-mailserver/values.yaml
@@ -301,8 +301,9 @@ service:
   ## unless you have a good reason not to.
   # externalTrafficPolicy: "Cluster"
   ## Traffic distribution preference for Services. One of:
-  ## - PreferSameZone
-  ## - PreferSameNode
+  ## - PreferClose
+  ## - PreferSameZone (started from 1.34)
+  ## - PreferSameNode (started from 1.34)
   ## Ref: https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution
   trafficDistribution: ""
   ## If there is a port associated with a given service, expose it here.


### PR DESCRIPTION
## Background

Add traffic distribution configuration to optimize Inter-AZ data transfer costs by enabling zone-aware traffic routing. This change introduces a new trafficDistribution field that allows configuring traffic locality preferences, zone affinity rules, and cross-AZ traffic minimization strategies. The implementation reduces cloud egress charges by prioritizing same-zone service-to-service communication while maintaining high availability through intelligent failover to other availability zones when local resources are unavailable.

## Changes

- Add spec.trafficDistribution field for service

## Reference

- [Traffic distribution](https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution)
- Similar to: https://github.com/kyverno/kyverno/pull/13411