### PR TITLE
feat: Add support containers.resizePolicy in deployments

### DIFF
--- a/charts/docker-mailserver/Chart.yaml
+++ b/charts/docker-mailserver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "15.0.2"
 description: A fullstack but simple mailserver (smtp, imap, antispam, antivirus, ssl...) using Docker.
 name: docker-mailserver
-version: 4.2.2
+version: 4.2.3
 sources:
 - https://github.com/docker-mailserver/docker-mailserver-helm
 maintainers:

--- a/charts/docker-mailserver/templates/deployment.yaml
+++ b/charts/docker-mailserver/templates/deployment.yaml
@@ -128,7 +128,7 @@ spec:
 
           resources:
 {{ toYaml .Values.deployment.resources | indent 12 }}
-          {{- if and .Values.deployment.resizePolicy (semverCompare ">=1.33-0" .Capabilities.KubeVersion.GitVersion) }}
+          {{- if and .Values.deployment.resizePolicy (semverCompare ">=1.33-0" .Capabilities.KubeVersion.Version) }}
           resizePolicy:
 {{ toYaml .Values.deployment.resizePolicy | indent 12 }}
           {{- end }}
@@ -276,7 +276,7 @@ spec:
               protocol: TCP
           resources:
 {{ toYaml .Values.metrics.resources | indent 12 }}
-          {{- if and .Values.metrics.resizePolicy (semverCompare ">=1.33-0" .Capabilities.KubeVersion.GitVersion) }}
+          {{- if and .Values.metrics.resizePolicy (semverCompare ">=1.33-0" .Capabilities.KubeVersion.Version) }}
           resizePolicy:
 {{ toYaml .Values.metrics.resizePolicy | indent 12 }}
           {{- end }}          

--- a/charts/docker-mailserver/templates/deployment.yaml
+++ b/charts/docker-mailserver/templates/deployment.yaml
@@ -128,6 +128,10 @@ spec:
 
           resources:
 {{ toYaml .Values.deployment.resources | indent 12 }}
+          {{- if .Values.deployment.resizePolicy }}
+          resizePolicy:
+{{ toYaml .Values.deployment.resizePolicy | indent 12 }}
+          {{- end }}
           securityContext:
             {{- if eq .Values.deployment.env.ENABLE_FAIL2BAN 1.0 }}
             capabilities:
@@ -271,7 +275,11 @@ spec:
               name: http
               protocol: TCP
           resources:
-{{ toYaml .Values.metrics.resources | indent 12 }}          
+{{ toYaml .Values.metrics.resources | indent 12 }}
+          {{- if .Values.metrics.resizePolicy }}
+          resizePolicy:
+{{ toYaml .Values.metrics.resizePolicy | indent 12 }}
+          {{- end }}          
           securityContext:
 {{ toYaml .Values.deployment.containerSecurityContext | indent 12 }}
 

--- a/charts/docker-mailserver/templates/deployment.yaml
+++ b/charts/docker-mailserver/templates/deployment.yaml
@@ -128,7 +128,7 @@ spec:
 
           resources:
 {{ toYaml .Values.deployment.resources | indent 12 }}
-          {{- if .Values.deployment.resizePolicy }}
+          {{- if and .Values.deployment.resizePolicy (semverCompare ">=1.33-0" .Capabilities.KubeVersion.GitVersion) }}
           resizePolicy:
 {{ toYaml .Values.deployment.resizePolicy | indent 12 }}
           {{- end }}
@@ -276,7 +276,7 @@ spec:
               protocol: TCP
           resources:
 {{ toYaml .Values.metrics.resources | indent 12 }}
-          {{- if .Values.metrics.resizePolicy }}
+          {{- if and .Values.metrics.resizePolicy (semverCompare ">=1.33-0" .Capabilities.KubeVersion.GitVersion) }}
           resizePolicy:
 {{ toYaml .Values.metrics.resizePolicy | indent 12 }}
           {{- end }}          

--- a/charts/docker-mailserver/values.yaml
+++ b/charts/docker-mailserver/values.yaml
@@ -262,6 +262,16 @@ deployment:
       memory: "2048Mi"
       ephemeral-storage: "500Mi"
 
+  ## Container resource resize policy for the docker-mailserver container
+  ## Allows dynamic adjustment of CPU and memory resources without pod restart
+  ## Useful for handling load spikes or optimizing resource utilization in production
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/resize-container-resources/
+  resizePolicy: []
+    # - resourceName: memory
+    #   restartPolicy: NotRequired
+    # - resourceName: cpu
+    #   restartPolicy: RestartContainer
+
   ## Optionally specify tolerations for the deployment
   tolerations: []
 
@@ -457,6 +467,16 @@ metrics:
     #limits:
     #  memory: "256Mi"
     #  cpu: "500M"
+
+  ## Container resource resize policy for the metrics-exporter container
+  ## Allows dynamic adjustment of CPU and memory resources without pod restart
+  ## Useful for handling load spikes or optimizing resource utilization in production
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/resize-container-resources/
+  resizePolicy: []
+    # - resourceName: memory
+    #   restartPolicy: NotRequired
+    # - resourceName: cpu
+    #   restartPolicy: RestartContainer
 
   serviceMonitor:
     enabled: false


### PR DESCRIPTION
## Summary

This PR adds support for Kubernetes container resource resize policy in the docker-mailserver Helm chart, enabling dynamic adjustment of CPU and memory resources without requiring pod restarts.

## Changes

- Added `containers.resizePolicy` configuration for both main docker-mailserver container and metrics-exporter container
- Updated deployment template to conditionally include resize policy when configured

## Reference

- [Resize CPU and Memory Resources assigned to Containers](https://kubernetes.io/docs/tasks/configure-pod-container/resize-container-resources/)