### PR TITLE
fix: shorten service name of managesieve-proxy

### DIFF
--- a/charts/docker-mailserver/Chart.yaml
+++ b/charts/docker-mailserver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "15.0.2"
 description: A fullstack but simple mailserver (smtp, imap, antispam, antivirus, ssl...) using Docker.
 name: docker-mailserver
-version: 4.2.2
+version: 4.2.3
 sources:
 - https://github.com/docker-mailserver/docker-mailserver-helm
 maintainers:

--- a/charts/docker-mailserver/templates/deployment.yaml
+++ b/charts/docker-mailserver/templates/deployment.yaml
@@ -250,7 +250,7 @@ spec:
             - name: managesieve
               containerPort: 4190  
           {{- if .Values.proxyProtocol.enabled }}
-            - name: managesieve-proxy
+            - name: msieve-proxy
               containerPort: 14190
           {{- end }}   
         {{- end }}  

--- a/charts/docker-mailserver/templates/service.yaml
+++ b/charts/docker-mailserver/templates/service.yaml
@@ -129,8 +129,8 @@ spec:
       targetPort: managesieve
       port: 4190  
     {{- if .Values.proxyProtocol.enabled }}
-    - name: managesieve-proxy
-      targetPort: managesieve-proxy
+    - name: msieve-proxy
+      targetPort: msieve-proxy
       port: 14190
     {{- end }}   
   {{- end }}   


### PR DESCRIPTION
When both `.Values.deployment.env.ENABLE_MANAGESIEVE` and  `.Values.proxyProtocol.enabled` are set, the resulting servicename would be `managesieve-proxy` which is too long for a service name (>15 chars). I've shortened it to `msieve-proxy` to fix that.
If that is an acceptable abbreviation, go ahead and merge, otherwise you are welcome to shorten the name to something else.
