### PR TITLE
fix: PROXY protocol should share postscreen cache

### DIFF
--- a/charts/docker-mailserver/tests/__snapshot__/configmap_test.yaml.snap
+++ b/charts/docker-mailserver/tests/__snapshot__/configmap_test.yaml.snap
@@ -63,8 +63,15 @@ manifest should match snapshot:
 
         # Create a variant for port 25 too (NOTE: Port 10025 is already assigned in DMS to Amavis):
         postconf -Mf smtp/inet | sed -e s/^smtp/12525/ >> /etc/postfix/master.cf
-        # Enable PROXY Protocol support (different setting as port 25 is handled via postscreen), optionally configure a `syslog_name` to distinguish in logs:
-        postconf -P 12525/inet/postscreen_upstream_proxy_protocol=haproxy 12525/inet/postscreen_cache_map=proxy:btree:\$data_directory/postscreen_12525_cache 12525/inet/syslog_name=postfix/smtpd-proxyprotocol
+        # Enable PROXY Protocol support:
+        # - Uses a different setting as port 25 is handled via the postscreen service
+        # - Optionally configure a `syslog_name` to distinguish in logs:
+        postconf -P \
+          12525/inet/postscreen_upstream_proxy_protocol=haproxy \
+          12525/inet/syslog_name=postfix/smtpd-proxyprotocol
+
+        # Add the `proxy:` prefix to share this cache between each running postscreen service via `proxymap`:
+        postconf 'postscreen_cache_map = proxy:btree:$data_directory/postscreen_cache'
     kind: ConfigMap
     metadata:
       labels:

--- a/charts/docker-mailserver/values.yaml
+++ b/charts/docker-mailserver/values.yaml
@@ -614,8 +614,15 @@ configMaps:
       
       # Create a variant for port 25 too (NOTE: Port 10025 is already assigned in DMS to Amavis):
       postconf -Mf smtp/inet | sed -e s/^smtp/12525/ >> /etc/postfix/master.cf
-      # Enable PROXY Protocol support (different setting as port 25 is handled via postscreen), optionally configure a `syslog_name` to distinguish in logs:
-      postconf -P 12525/inet/postscreen_upstream_proxy_protocol=haproxy 12525/inet/postscreen_cache_map=proxy:btree:\$data_directory/postscreen_12525_cache 12525/inet/syslog_name=postfix/smtpd-proxyprotocol
+      # Enable PROXY Protocol support:
+      # - Uses a different setting as port 25 is handled via the postscreen service
+      # - Optionally configure a `syslog_name` to distinguish in logs:
+      postconf -P \
+        12525/inet/postscreen_upstream_proxy_protocol=haproxy \
+        12525/inet/syslog_name=postfix/smtpd-proxyprotocol
+
+      # Add the `proxy:` prefix to share this cache between each running postscreen service via `proxymap`:
+      postconf 'postscreen_cache_map = proxy:btree:$data_directory/postscreen_cache'
       {{- end }}
 
 ## The secrets key works the same way as the configs key. Use secrets to store sensitive information,


### PR DESCRIPTION
Implements a fix based on findings at: https://github.com/docker-mailserver/docker-mailserver-helm/issues/186#issuecomment-3314469131

This was [observed earlier back in April 2025](https://github.com/docker-mailserver/docker-mailserver-helm/pull/156#issuecomment-2807740319) and pointed out as not aligned with our docs guidance. Managing the setting via `user-patches.sh` as I've contributed here is better than the current DMS docs advice with `postfix-main.cf`, so I'll update that over there too.

This approach to share the postscreen cache is motivated from [this DMS issue](https://github.com/docker-mailserver/docker-mailserver/issues/4058#issuecomment-2159610114).
- Technically depending how it's leveraged privately, perhaps there could be some overlap with public entries in the cache that could be exploited?
- Without further investigating how the cache is managed and putting more thought into it, I'm not able to weigh in much on that concern, or any other risks.

Should it be an issue, separate cache maps can be configured and `proxy_write_maps` should be updated as per https://github.com/docker-mailserver/docker-mailserver-helm/issues/186#issuecomment-3314469091

---

Fixes: #186 

