### PR TITLE
Correctly use ports for Prometheus exporter

### DIFF
--- a/charts/docker-mailserver/templates/deployment.yaml
+++ b/charts/docker-mailserver/templates/deployment.yaml
@@ -272,7 +272,7 @@ spec:
 
           ports:
             - containerPort: 9154
-              name: http
+              name: metrics
               protocol: TCP
           resources:
 {{ toYaml .Values.metrics.resources | indent 12 }}

--- a/charts/docker-mailserver/templates/service.yaml
+++ b/charts/docker-mailserver/templates/service.yaml
@@ -138,7 +138,7 @@ spec:
   {{- if .Values.metrics.enabled }}
     - name: metrics
       port: 9154
-      targetPort: 9154       
+      targetPort: metrics       
   {{- end }}
 
   type: {{ default "ClusterIP" .Values.service.type }}

--- a/charts/docker-mailserver/templates/service.yaml
+++ b/charts/docker-mailserver/templates/service.yaml
@@ -137,7 +137,7 @@ spec:
  
   {{- if .Values.metrics.enabled }}
     - name: metrics
-      port: 9154
+      port: {{ .Values.monitoring.service.port }}
       targetPort: metrics       
   {{- end }}
 


### PR DESCRIPTION
I found that the `values.yaml` states that you can configure the port for the Prometheus exporter, but in the end it was always 9154. Even though the docs stated 9102 as a default value. In my case, it doesn't work at all.

I think this will fix it.