### PR TITLE
fix: properly reference pod's securityContext from values and add deployment.securityContext.runAsNonRoot=true

### DIFF
--- a/charts/docker-mailserver/Chart.yaml
+++ b/charts/docker-mailserver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "15.1.0"
 description: A fullstack but simple mailserver (smtp, imap, antispam, antivirus, ssl...) using Docker.
 name: docker-mailserver
-version: 5.1.1
+version: 5.1.2
 sources:
 - https://github.com/docker-mailserver/docker-mailserver-helm
 maintainers:

--- a/charts/docker-mailserver/templates/deployment.yaml
+++ b/charts/docker-mailserver/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
       restartPolicy: "Always"
       serviceAccountName: {{ template "dockermailserver.serviceAccountName" . }}
       securityContext:
-{{ toYaml .Values.securityContext | indent 8 }}
+        {{- toYaml .Values.deployment.securityContext | indent 8 }}
       {{- if .Values.deployment.tolerations }}
       tolerations: {{- toYaml .Values.deployment.tolerations | nindent 8 }}
       {{ end }}
@@ -217,7 +217,7 @@ spec:
               containerPort: 10465
             - name: sub-proxy
               containerPort: 10587
-          {{- end }}   
+          {{- end }}
 
         {{- if and (.Values.deployment.env.ENABLE_IMAP) (not .Values.deployment.env.SMTP_ONLY) }}
             - name: imap
@@ -229,8 +229,8 @@ spec:
               containerPort: 10143
             - name: imaps-proxy
               containerPort: 10993
-          {{- end }}   
-        {{- end }}   
+          {{- end }}
+        {{- end }}
 
         {{- if and (.Values.deployment.env.ENABLE_POP3) (not .Values.deployment.env.SMTP_ONLY) }}
             - name: pop3
@@ -242,29 +242,29 @@ spec:
               containerPort: 10110
             - name: pop3s-proxy
               containerPort: 10995
-          {{- end }}   
-        {{- end }}  
+          {{- end }}
+        {{- end }}
 
         {{- if .Values.deployment.env.ENABLE_RSPAMD }}
             - name: rspamd
-              containerPort: 11334  
-        {{- end }}  
+              containerPort: 11334
+        {{- end }}
 
         {{- if and (.Values.deployment.env.ENABLE_MANAGESIEVE) (not .Values.deployment.env.SMTP_ONLY) }}
             - name: managesieve
-              containerPort: 4190  
+              containerPort: 4190
           {{- if .Values.proxyProtocol.enabled }}
             - name: msieve-proxy
               containerPort: 14190
-          {{- end }}   
-        {{- end }}  
+          {{- end }}
+        {{- end }}
 
 {{- if .Values.metrics.enabled }}
         - name: metrics-exporter
           image: {{ .Values.metrics.image.name }}:{{ .Values.metrics.image.tag }}
           imagePullPolicy: {{ .Values.metrics.image.pullPolicy }}
           command: ["/bin/postfix_exporter"]
-          args: 
+          args:
             - "--postfix.showq_path"
             - "/var/mail-state/spool-postfix/public/showq"
             - "--postfix.logfile_path"
@@ -279,7 +279,7 @@ spec:
           {{- if and .Values.metrics.resizePolicy (semverCompare ">=1.33-0" .Capabilities.KubeVersion.Version) }}
           resizePolicy:
 {{ toYaml .Values.metrics.resizePolicy | indent 12 }}
-          {{- end }}          
+          {{- end }}
           securityContext:
 {{ toYaml .Values.deployment.containerSecurityContext | indent 12 }}
 

--- a/charts/docker-mailserver/templates/deployment.yaml
+++ b/charts/docker-mailserver/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
       restartPolicy: "Always"
       serviceAccountName: {{ template "dockermailserver.serviceAccountName" . }}
       securityContext:
-        {{- toYaml .Values.deployment.securityContext | indent 8 }}
+{{ toYaml .Values.deployment.securityContext | indent 8 }}
       {{- if .Values.deployment.tolerations }}
       tolerations: {{- toYaml .Values.deployment.tolerations | nindent 8 }}
       {{ end }}

--- a/charts/docker-mailserver/values.yaml
+++ b/charts/docker-mailserver/values.yaml
@@ -225,6 +225,7 @@ deployment:
     #RELAY_PASSWORD:
 
   securityContext:
+    runAsNonRoot: true
     runAsUser: 5000
     runAsGroup: 5000
 


### PR DESCRIPTION
The securityContext from the deployment was referencing a non-existing value. It was never applied.