### PR TITLE
Acknowledge the reality of securityContext handling

### DIFF
--- a/charts/docker-mailserver/Chart.yaml
+++ b/charts/docker-mailserver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "15.1.0"
 description: A fullstack but simple mailserver (smtp, imap, antispam, antivirus, ssl...) using Docker.
 name: docker-mailserver
-version: 5.1.1
+version: 5.1.2
 sources:
 - https://github.com/docker-mailserver/docker-mailserver-helm
 maintainers:

--- a/charts/docker-mailserver/templates/deployment.yaml
+++ b/charts/docker-mailserver/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
       restartPolicy: "Always"
       serviceAccountName: {{ template "dockermailserver.serviceAccountName" . }}
       securityContext:
-{{ toYaml .Values.securityContext | indent 8 }}
+{{ toYaml (coalesce .Values.deployment.securityContext .Values.securityContext) | indent 8 }}
       {{- if .Values.deployment.tolerations }}
       tolerations: {{- toYaml .Values.deployment.tolerations | nindent 8 }}
       {{ end }}
@@ -217,7 +217,7 @@ spec:
               containerPort: 10465
             - name: sub-proxy
               containerPort: 10587
-          {{- end }}   
+          {{- end }}
 
         {{- if and (.Values.deployment.env.ENABLE_IMAP) (not .Values.deployment.env.SMTP_ONLY) }}
             - name: imap
@@ -229,8 +229,8 @@ spec:
               containerPort: 10143
             - name: imaps-proxy
               containerPort: 10993
-          {{- end }}   
-        {{- end }}   
+          {{- end }}
+        {{- end }}
 
         {{- if and (.Values.deployment.env.ENABLE_POP3) (not .Values.deployment.env.SMTP_ONLY) }}
             - name: pop3
@@ -242,29 +242,29 @@ spec:
               containerPort: 10110
             - name: pop3s-proxy
               containerPort: 10995
-          {{- end }}   
-        {{- end }}  
+          {{- end }}
+        {{- end }}
 
         {{- if .Values.deployment.env.ENABLE_RSPAMD }}
             - name: rspamd
-              containerPort: 11334  
-        {{- end }}  
+              containerPort: 11334
+        {{- end }}
 
         {{- if and (.Values.deployment.env.ENABLE_MANAGESIEVE) (not .Values.deployment.env.SMTP_ONLY) }}
             - name: managesieve
-              containerPort: 4190  
+              containerPort: 4190
           {{- if .Values.proxyProtocol.enabled }}
             - name: msieve-proxy
               containerPort: 14190
-          {{- end }}   
-        {{- end }}  
+          {{- end }}
+        {{- end }}
 
 {{- if .Values.metrics.enabled }}
         - name: metrics-exporter
           image: {{ .Values.metrics.image.name }}:{{ .Values.metrics.image.tag }}
           imagePullPolicy: {{ .Values.metrics.image.pullPolicy }}
           command: ["/bin/postfix_exporter"]
-          args: 
+          args:
             - "--postfix.showq_path"
             - "/var/mail-state/spool-postfix/public/showq"
             - "--postfix.logfile_path"
@@ -279,7 +279,7 @@ spec:
           {{- if and .Values.metrics.resizePolicy (semverCompare ">=1.33-0" .Capabilities.KubeVersion.Version) }}
           resizePolicy:
 {{ toYaml .Values.metrics.resizePolicy | indent 12 }}
-          {{- end }}          
+          {{- end }}
           securityContext:
 {{ toYaml .Values.deployment.containerSecurityContext | indent 12 }}
 

--- a/charts/docker-mailserver/templates/pvc.yaml
+++ b/charts/docker-mailserver/templates/pvc.yaml
@@ -6,15 +6,15 @@ metadata:
   name: {{ template "dockermailserver.fullname" $ }}-{{ $name }}
   {{- if $pvc.annotations }}
   annotations:
-    {{ toYaml $pvc.annotations }}  
+    {{ toYaml $pvc.annotations }}
   {{ end }}
 spec:
   accessModes:
   {{ toYaml $pvc.accessModes | indent 2 }}
-    
+
   {{- if $pvc.storageClass }}
   storageClassName: {{ $pvc.storageClass | quote }}
-  {{- end }}    
+  {{- end }}
   resources:
     requests:
       storage: {{ $pvc.size | quote }}

--- a/charts/docker-mailserver/templates/servicemonitor.yaml
+++ b/charts/docker-mailserver/templates/servicemonitor.yaml
@@ -10,7 +10,7 @@ metadata:
     release: "{{ .Release.Name }}"
 {{- if .Values.metrics.serviceMonitor.labels }}
 {{ toYaml .Values.metrics.serviceMonitor.labels | indent 4 }}
-{{ end }}    
+{{ end }}
   name: {{ template "dockermailserver.fullname" . }}
 spec:
   endpoints:

--- a/charts/docker-mailserver/values.yaml
+++ b/charts/docker-mailserver/values.yaml
@@ -224,9 +224,7 @@ deployment:
     # set those unless you're using a secret
     #RELAY_PASSWORD:
 
-  securityContext:
-    runAsUser: 5000
-    runAsGroup: 5000
+  securityContext: {}
 
   containerSecurityContext:
     readOnlyRootFilesystem: false # incompatible with the way docker-mailserver works
@@ -618,7 +616,7 @@ configMaps:
       # Enable PROXY Protocol support for these new service variants:
       postconf -P 10587/inet/smtpd_upstream_proxy_protocol=haproxy
       postconf -P 10465/inet/smtpd_upstream_proxy_protocol=haproxy
-      
+
       # Create a variant for port 25 too (NOTE: Port 10025 is already assigned in DMS to Amavis):
       postconf -Mf smtp/inet | sed -e s/^smtp/12525/ >> /etc/postfix/master.cf
       # Enable PROXY Protocol support:


### PR DESCRIPTION
This has been touched on elsewhere, but I wanted to make it official to try to save other people time and confusion.

This PR does 2.5 things:
1. Cleans up trailing whitespace
2. Adds a `coalesce` that prioritizes taking `securityContext` config from `.deployment.securityContext`, but falls back to `.securityContext` to try to maintain existing mappings.
    1. I'd vote for removing the `coalesce` as part of 6.x release.
4. Replaces the unused default `securityContext` config with an empty object to try to maintain existing default configuration and be honest about what's really happening upon deployment.

If you disagree with any of these choices, let me know. Feedback is welcome.

Related:
- [Invalid Pod securityContext Configuration](https://github.com/docker-mailserver/docker-mailserver-helm/issues/163) (not sure why this was closed) 
- [fix: properly reference pod's securityContext from values and add deployment.securityContext.runAsNonRoot=true](https://github.com/docker-mailserver/docker-mailserver-helm/pull/197)